### PR TITLE
feat: 특정 유저 채팅 고정 기능 추가

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,6 +5,7 @@ import { Select } from "./components/input/Select/Select";
 import Checkbox from "./components/input/Checkbox/Checkbox";
 import URLButton from "./components/button/URLButton/URLButton";
 import ColorPicker from "./components/input/ColorPicker/ColorPicker";
+import List from "./components/List/List";
 
 import {
   AUDIO_COMPRESSOR,
@@ -20,6 +21,8 @@ import {
   CHEEZE_REMOVER,
   FAST_BUTTON,
   FOLLOWING_REFRESH_ENABLE,
+  MESSAGE_PIN_ENABLE,
+  MESSAGE_PIN_USERS,
   ONLIVE_REFRESH,
   PIP_BUTTON,
   PREVIEW_ENABLE,
@@ -207,6 +210,24 @@ function App() {
               <p className="menu-desc">새로고침 후 적용</p>
             </div>
           </Select>
+
+          <Checkbox id={MESSAGE_PIN_ENABLE}>
+            <div className="menu">
+              <p className="menu-title">메시지 고정 기능 *</p>
+              <p className="menu-desc">새로고침 후 적용</p>
+            </div>
+          </Checkbox>
+
+          <List
+            id={MESSAGE_PIN_USERS}
+            saveButtonText="추가"
+            inputPlaceholder="닉네임 입력"
+          >
+            <div className="menu">
+              <p className="menu-title">유저 고정 리스트 *</p>
+              <p className="menu-desc">새로고침 후 적용</p>
+            </div>
+          </List>
         </div>
       </div>
 

--- a/src/components/List/List.css
+++ b/src/components/List/List.css
@@ -1,0 +1,44 @@
+#czp-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+#czp-list-item {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  border-radius: 8px;
+  position: relative;
+  width: 100%;
+  color: #c9cedc;
+  font-size: 14px;
+  line-height: 1.2;
+  user-select: none;
+  height: fit-content;
+  padding-block: 5px;
+  font-weight: 600;
+
+  span {
+    margin-left: 0.5rem;
+  }
+
+  button {
+    margin-right: 0.5rem;
+  }
+}
+
+#czp-list-item:hover {
+  text-decoration: none;
+  background-color: hsla(0, 0%, 100%, 0.1);
+}
+
+#czp-list-input-wrapper {
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+}
+
+#czp-list-input-wrapper input {
+  flex: 1;
+}

--- a/src/components/List/List.tsx
+++ b/src/components/List/List.tsx
@@ -1,0 +1,72 @@
+import { useEffect, useState } from "react";
+import "./List.css";
+import TextInput from "../input/TextInput/TextInput";
+import TextButton from "../button/TextButton/TextButton";
+import CloseButton from "../button/CloseButton/CloseButton";
+
+interface ListProps extends React.HTMLAttributes<HTMLDivElement> {
+  id: string;
+  inputPlaceholder?: string;
+  saveButtonText?: string;
+}
+
+const List = ({
+  children,
+  id,
+  inputPlaceholder = "입력해주세요",
+  saveButtonText = "추가",
+  ...props
+}: ListProps) => {
+  const [listItems, setListItems] = useState<string[]>([]);
+  const [newItem, setNewItem] = useState<string>("");
+
+  useEffect(() => {
+    chrome.storage.local.get([id], (result) => {
+      if (result[id]) {
+        setListItems(result[id]);
+      }
+    });
+  }, []);
+
+  const handleAddItem = () => {
+    if (newItem.trim() !== "") {
+      const updatedItems = [...listItems, newItem.trim()];
+      setListItems(updatedItems);
+      setNewItem("");
+      chrome.storage.local.set({ [id]: updatedItems });
+    }
+  };
+
+  const handleRemoveItem = (index: number) => {
+    const updatedItems = listItems.filter((_, i) => i !== index);
+    setListItems(updatedItems);
+    chrome.storage.local.set({ [id]: updatedItems });
+  };
+
+  return (
+    <div id="czp-list" {...props}>
+      {children}
+      <div id="czp-list-input-wrapper">
+        <TextInput
+          value={newItem}
+          onChange={(e) => setNewItem(e.target.value)}
+          placeholder={inputPlaceholder}
+        >
+          <TextButton
+            text={saveButtonText}
+            onClick={handleAddItem}
+            isActive={newItem.trim() !== ""}
+          />
+        </TextInput>
+      </div>
+      {listItems.map((item, index) => (
+        <div key={index} id="czp-list-item">
+          <span>{item}</span>
+          <CloseButton onClick={() => handleRemoveItem(index)} />
+        </div>
+      ))}
+    </div>
+  );
+};
+
+export default List;

--- a/src/components/button/CloseButton/CloseButton.css
+++ b/src/components/button/CloseButton/CloseButton.css
@@ -1,0 +1,25 @@
+#close-button {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  cursor: pointer;
+  color: #9da5b6;
+  outline: none;
+  background: 0 0;
+  border: 0;
+  border-radius: 5px;
+  box-sizing: border-box;
+  padding: 4px;
+  width: 24px;
+  height: 24px;
+
+  svg {
+    width: 13px;
+    height: 13px;
+    flex-shrink: 0;
+  }
+}
+
+#close-button:hover {
+  background-color: hsla(0, 0%, 100%, 0.1);
+}

--- a/src/components/button/CloseButton/CloseButton.tsx
+++ b/src/components/button/CloseButton/CloseButton.tsx
@@ -1,0 +1,33 @@
+import { ButtonHTMLAttributes } from "react";
+import "./CloseButton.css";
+
+interface CloseButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {}
+
+export const CloseButton = ({ ...props }: CloseButtonProps) => {
+  return (
+    <button type="button" id="close-button" {...props}>
+      <svg
+        width="16"
+        height="16"
+        viewBox="10 10 10 10"
+        fill="none"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M10 10L20 20"
+          stroke="currentColor"
+          strokeWidth="1.8"
+          strokeLinecap="round"
+        ></path>
+        <path
+          d="M20.0001 10L10.0001 20"
+          stroke="currentColor"
+          strokeWidth="1.8"
+          strokeLinecap="round"
+        ></path>
+      </svg>
+    </button>
+  );
+};
+
+export default CloseButton;

--- a/src/components/button/TextButton/TextButton.css
+++ b/src/components/button/TextButton/TextButton.css
@@ -1,0 +1,23 @@
+#text-button {
+  background-color: #2e3033;
+  border-radius: 8px;
+  color: rgba(255, 255, 255, 0.4);
+  flex: none;
+  font-size: 13px;
+  height: 28px;
+  margin-left: auto;
+  padding: 0 9px;
+  outline: none;
+  cursor: pointer;
+  box-sizing: border-box;
+  border: 0;
+  font-weight: 900;
+}
+#text-button:hover {
+  background-color: hsla(0, 0%, 100%, 0.1);
+}
+
+#text-button.isActive {
+  background-color: rgba(0, 255, 163, 0.9);
+  color: #000;
+}

--- a/src/components/button/TextButton/TextButton.tsx
+++ b/src/components/button/TextButton/TextButton.tsx
@@ -1,0 +1,28 @@
+import { ButtonHTMLAttributes } from "react";
+import "./TextButton.css";
+
+interface TextButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
+  text: string;
+  isActive?: boolean;
+  className?: string;
+}
+
+export const TextButton = ({
+  text,
+  isActive = false,
+  className = "",
+  ...props
+}: TextButtonProps) => {
+  return (
+    <button
+      type="button"
+      id="text-button"
+      className={`${className} ${isActive && "isActive"}`}
+      {...props}
+    >
+      {text}
+    </button>
+  );
+};
+
+export default TextButton;

--- a/src/components/button/UserPinButton/UserPinButton.tsx
+++ b/src/components/button/UserPinButton/UserPinButton.tsx
@@ -1,0 +1,86 @@
+import { useState, useEffect } from "react";
+import { USER_POPUP_NAME } from "../../../constants/class";
+import { MESSAGE_PIN_USERS } from "../../../constants/storage";
+
+export default function UserPinButton() {
+  const [isPinned, setIsPinned] = useState(false);
+  const [userName, setUserName] = useState("");
+
+  useEffect(() => {
+    const userNameElement = document.querySelector(USER_POPUP_NAME);
+    if (userNameElement?.textContent) {
+      setUserName(userNameElement.textContent);
+      chrome.storage.local.get([MESSAGE_PIN_USERS], (res) => {
+        const pinnedUsers = res[MESSAGE_PIN_USERS] || [];
+        setIsPinned(pinnedUsers.includes(userNameElement.textContent));
+      });
+    }
+    return () => {
+      setUserName("");
+      setIsPinned(false);
+    };
+  }, []);
+
+  const handlerClick = () => {
+    if (!userName) return;
+
+    chrome.storage.local.get([MESSAGE_PIN_USERS], (res) => {
+      const pinnedUsers = res[MESSAGE_PIN_USERS] || [];
+      let newPinnedUsers: string[];
+
+      if (isPinned) {
+        newPinnedUsers = pinnedUsers.filter(
+          (user: string) => user !== userName
+        );
+      } else {
+        newPinnedUsers = [...pinnedUsers, userName];
+      }
+
+      chrome.storage.local.set(
+        {
+          [MESSAGE_PIN_USERS]: newPinnedUsers,
+        },
+        () => {
+          setIsPinned((prev) => !prev);
+        }
+      );
+    });
+  };
+
+  return (
+    <button
+      onClick={handlerClick}
+      className="live_chatting_popup_profile_item__tOguB"
+      id="chzzk-plus-user-pin-btn"
+    >
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        width="20"
+        height="20"
+        fill="none"
+        className="live_chatting_fixed_icon_pin__jecmM"
+        aria-hidden="true"
+      >
+        <path
+          fill="currentColor"
+          fillRule="evenodd"
+          d="m11.18 4.207.024.272-.01-.01-1.916 1.924A1.595 1.595 0 0 0 9 6.387l-2.356.156A.602.602 0 0 0 6.26 7.57l4.223 4.242.007.006.465.467a.598.598 0 0 0 1.021-.397l.03-.66.001-.009.082-1.761c.002-.04.003-.081.002-.121l1.974-1.984-.01-.01.27.023.25.022a.3.3 0 0 0 .238-.512l-.178-.179-.625-.628-.019-.019-.183-.184-1.133-1.138-.184-.185-.018-.018-.625-.628-.178-.179a.3.3 0 0 0-.51.239l.022.251Z"
+          clipRule="evenodd"
+        ></path>
+        <path
+          fill="currentColor"
+          d="m11.204 4.48-.353.353.969.973-.119-1.37-.497.043Zm-.023-.273.497-.043-.497.043Zm.013.262.352-.355-.352-.354-.353.354.353.355ZM9.278 6.393l-.054.498.238.026.17-.17-.354-.354ZM9 6.387l.033.5-.033-.5Zm-2.356.156.033.5-.033-.5Zm5.332 5.344-.498-.023.498.023Zm.03-.66-.498-.023.499.023Zm.001-.009.499.024v-.004l-.499-.02Zm0 0-.498-.023v.004l.498.02Zm.082-1.761.499.023-.499-.023Zm.002-.121-.353-.355-.152.153.006.216.498-.014Zm1.974-1.984.353.354.353-.354-.353-.354-.353.354Zm-.01-.01.043-.5-1.365-.12.969.974.352-.355Zm.27.023.043-.5-.043.5Zm.25.022-.043.5.043-.5ZM11.16 3.956l-.497.043.497-.043Zm.542.48-.023-.272-.994.087.023.272.994-.087Zm-.86.387.01.01.706-.708-.01-.01-.706.708Zm-1.21 1.924 1.915-1.924-.705-.709-1.915 1.924.705.709Zm-.299-.853a2.091 2.091 0 0 0-.366-.007l.066 1c.065-.005.13-.003.192.004l.108-.997Zm-.366-.007-2.356.156.066 1 2.356-.156-.066-1Zm-2.356.156c-.941.063-1.37 1.21-.703 1.88l.705-.709a.1.1 0 0 1 .064-.17l-.066-1Zm-.703 1.88 4.222 4.242.706-.709-4.223-4.242-.705.71Zm4.222 4.242.706-.709-.706.709Zm0 0 .007.007.705-.71-.006-.006-.706.709Zm.007.007.465.466.705-.708-.465-.467-.705.709Zm.465.466c.674.678 1.828.229 1.872-.727l-.996-.047a.095.095 0 0 1-.018.055.106.106 0 0 1-.046.033.104.104 0 0 1-.056.007.093.093 0 0 1-.05-.03l-.706.71Zm1.872-.727.031-.66-.996-.047-.031.66.996.046Zm.031-.66v-.01l-.996-.046v.009l.996.047Zm0-.013-.996-.04.997.04Zm0 .004.083-1.762-.997-.047-.082 1.762.997.046Zm.083-1.762c.002-.053.003-.106.001-.158l-.997.028v.083l.996.047Zm1.124-2.482L11.737 8.98l.705.71 1.975-1.985-.706-.708Zm-.01.698.01.01.706-.708-.01-.011-.706.709Zm.666-.83-.27-.024-.087.998.27.024.087-.998Zm.25.022-.25-.022-.086.998.25.022.087-.998Zm-.158.341a.2.2 0 0 1 .159-.341l-.087.998c.742.065 1.16-.836.634-1.366l-.706.709Zm-.178-.179.178.179.706-.709-.178-.178-.706.708Zm-.625-.627.625.627.706-.708-.625-.628-.706.709Zm-.018-.02.018.02.706-.71-.019-.018-.705.709Zm-.184-.184.184.185.705-.71-.183-.183-.706.708Zm-1.133-1.138 1.133 1.138.706-.708-1.133-1.139-.706.71Zm-.183-.184.183.184.706-.709-.184-.184-.705.709Zm-.02-.02.02.02.705-.709-.019-.019-.705.709Zm-.624-.627.625.628.705-.709-.625-.628-.705.709Zm-.178-.179.178.179.705-.709-.178-.178-.705.708Zm.34-.159a.2.2 0 0 1-.34.16l.705-.71c-.526-.528-1.424-.108-1.36.637l.995-.087Zm.022.252-.022-.252-.994.087.022.252.994-.087Z"
+        ></path>
+        <path
+          fill="currentColor"
+          fillRule="evenodd"
+          stroke="currentColor"
+          strokeWidth="0.5"
+          d="M6.674 11.13 7.5 12l-2.665 2.166c-.26.185-.578-.138-.394-.4l2.233-2.637Z"
+          clipRule="evenodd"
+        ></path>
+      </svg>
+      <span>{isPinned ? "유저 메시지 고정 해제" : "유저 메시지 고정"}</span>
+    </button>
+  );
+}

--- a/src/components/input/TextInput/TextInput.css
+++ b/src/components/input/TextInput/TextInput.css
@@ -1,0 +1,28 @@
+#text-input-container {
+  align-items: center;
+  background-color: #373a3f;
+  border-radius: 8px;
+  display: flex;
+  padding: 3px 5px;
+  position: relative;
+  width: 100%;
+}
+
+#text-input-container input {
+  height: 40px;
+  margin: -10px 0 -10px 4px;
+  padding: 10px 0;
+  background-color: transparent;
+  border: 0;
+  color: #dfe2ea;
+  line-height: 20px;
+  margin-left: 4px;
+  max-height: 60px;
+  min-height: 20px;
+  outline: none;
+  overflow-y: auto;
+  position: relative;
+  resize: none;
+  white-space: normal;
+  width: 100%;
+}

--- a/src/components/input/TextInput/TextInput.tsx
+++ b/src/components/input/TextInput/TextInput.tsx
@@ -1,0 +1,29 @@
+import "./TextInput.css";
+
+interface TextInputProps extends React.InputHTMLAttributes<HTMLInputElement> {
+  placeholder?: string;
+  className?: string;
+}
+
+export const TextInput = ({
+  value,
+  onChange,
+  placeholder = "",
+  children,
+  ...props
+}: TextInputProps) => {
+  return (
+    <div id="text-input-container">
+      <input
+        type="text"
+        placeholder={placeholder}
+        value={value}
+        onChange={onChange}
+        {...props}
+      />
+      {children}
+    </div>
+  );
+};
+
+export default TextInput;

--- a/src/components/pinnedMessageBox/PinnedMessageBox.css
+++ b/src/components/pinnedMessageBox/PinnedMessageBox.css
@@ -1,0 +1,104 @@
+#chzzk-plus-message-pin {
+  /* 메시지 핀 리스트 스타일 */
+  .czp-message-pin-list {
+    border-radius: 0 0 6px 6px;
+    background-color: rgba(var(--color-bg-white-rgb), 0.04);
+    background-image: linear-gradient(
+      rgba(var(--color-bg-layer-02-rgb), 0.7),
+      rgba(var(--color-bg-layer-02-rgb), 0.7)
+    );
+    -webkit-box-shadow: 0 8px 6px 0 var(--color-shadow-layer04-02),
+      0 0 1px 0 var(--color-shadow-layer04-01);
+    box-shadow: 0 8px 6px 0 var(--color-shadow-layer04-02),
+      0 0 1px 0 var(--color-shadow-layer04-01);
+    position: relative;
+    height: fit-content;
+    max-height: 40vh;
+    overflow-y: auto;
+    z-index: 1000;
+    top: unset;
+    display: none;
+  }
+
+  .live_chatting_fixed_mission_header__EvP2K.isOpen + .czp-message-pin-list {
+    display: block;
+
+    button {
+      cursor: default;
+    }
+  }
+
+  /* 스크롤바 스타일 */
+  .czp-message-pin-list::-webkit-scrollbar {
+    width: 5px;
+  }
+
+  .czp-message-pin-list::-webkit-scrollbar-thumb {
+    background-color: rgb(158, 158, 158);
+    border-radius: 10px;
+  }
+
+  .czp-message-pin-list::-webkit-scrollbar-track {
+    background-color: rgb(71, 71, 71);
+    border-radius: 10px;
+    background-clip: padding-box;
+  }
+
+  /* 헤더 스타일 */
+  .live_chatting_fixed_mission_header__EvP2K {
+    border-bottom: none !important;
+    user-select: none;
+    -webkit-user-select: none;
+    -moz-user-select: none;
+    -ms-user-select: none;
+    cursor: pointer;
+    border-radius: 8px 8px 0 0 !important;
+    display: flex;
+    align-items: center;
+  }
+
+  .live_chatting_fixed_mission_header__EvP2K:not(.isOpen) {
+    border-radius: 8px !important;
+  }
+
+  /* 버튼 및 아이콘 스타일 */
+  .live_chatting_fixed_mission_mission_button__GkYx4 {
+    padding: 0px !important;
+  }
+
+  .live_chatting_fixed_mission_folded_button__bBWS2 {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
+
+  #chzzk-plus-message-pin-title-container {
+    display: inline-flex;
+    align-items: center;
+    margin-left: 5px;
+  }
+
+  /* 새 메시지 표시 스타일 */
+  #chzzk-plus-new-message-dot {
+    color: red;
+    font-size: 20px;
+    margin-left: 4px;
+    display: none;
+  }
+
+  /* 빈 메시지 스타일 */
+  #chzzk-plus-message-pin-empty-message {
+    padding: 12px;
+    text-align: center;
+    color: var(--color-text-sub);
+    font-family: Sandoll Nemony2;
+  }
+
+  /* 채팅 리스트 마진 수정 */
+  .czp-message-pin-list .live_chatting_list_item__0SGhw:first-child:before {
+    content: "";
+    display: block;
+    height: 0px !important;
+    margin-top: 0px !important;
+  }
+}

--- a/src/components/pinnedMessageBox/PinnedMessageBox.tsx
+++ b/src/components/pinnedMessageBox/PinnedMessageBox.tsx
@@ -1,0 +1,127 @@
+import { useState, useRef, useEffect } from "react";
+import "./PinnedMessageBox.css";
+
+export default function PinnedMessageBox() {
+  const [isOpen, setIsOpen] = useState(false);
+  const [isScrolledUp, setIsScrolledUp] = useState(false);
+  const [hasMessages, setHasMessages] = useState(false);
+  const pinListRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const pinList = pinListRef.current;
+    if (!pinList) return;
+
+    const handleScroll = () => {
+      const { scrollTop, scrollHeight, clientHeight } = pinList;
+      setIsScrolledUp(scrollTop + clientHeight < scrollHeight);
+    };
+
+    pinList.addEventListener("scroll", handleScroll);
+    return () => pinList.removeEventListener("scroll", handleScroll);
+  }, []);
+
+  useEffect(() => {
+    const pinList = pinListRef.current;
+    if (!pinList || isScrolledUp) return;
+
+    const scrollToBottom = () => {
+      pinList.scrollTop = pinList.scrollHeight;
+    };
+
+    scrollToBottom();
+    const observer = new MutationObserver(() => {
+      scrollToBottom();
+      setHasMessages(pinList.childNodes.length > 0);
+    });
+    observer.observe(pinList, { childList: true, subtree: true });
+
+    return () => observer.disconnect();
+  }, [isScrolledUp]);
+
+  const handleToggleOpen = () => {
+    setIsOpen((prev) => !prev);
+    const newMessageDot = document.getElementById("chzzk-plus-new-message-dot");
+    if (newMessageDot) {
+      newMessageDot.style.display = "none";
+    }
+  };
+
+  return (
+    <div
+      className="live_chatting_list_fixed__Wy3TT"
+      id="chzzk-plus-message-pin"
+      style={{ top: "unset" }}
+    >
+      <div className="live_chatting_fixed_mission_container__T6EY5">
+        <div
+          className={`live_chatting_fixed_mission_header__EvP2K ${
+            isOpen ? "isOpen" : ""
+          }`}
+          onClick={handleToggleOpen}
+        >
+          <div id="chzzk-plus-message-pin-title-container">
+            <span
+              id="chzzk-plus-message-pin-title"
+              className="live_chatting_fixed_mission_mission_button__GkYx4"
+            >
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                width="20"
+                height="20"
+                fill="none"
+                className="live_chatting_fixed_icon_pin__jecmM"
+                aria-hidden="true"
+              >
+                <path
+                  fill="currentColor"
+                  fillRule="evenodd"
+                  d="m11.18 4.207.024.272-.01-.01-1.916 1.924A1.595 1.595 0 0 0 9 6.387l-2.356.156A.602.602 0 0 0 6.26 7.57l4.223 4.242.007.006.465.467a.598.598 0 0 0 1.021-.397l.03-.66.001-.009.082-1.761c.002-.04.003-.081.002-.121l1.974-1.984-.01-.01.27.023.25.022a.3.3 0 0 0 .238-.512l-.178-.179-.625-.628-.019-.019-.183-.184-1.133-1.138-.184-.185-.018-.018-.625-.628-.178-.179a.3.3 0 0 0-.51.239l.022.251Z"
+                  clipRule="evenodd"
+                ></path>
+                <path
+                  fill="currentColor"
+                  d="m11.204 4.48-.353.353.969.973-.119-1.37-.497.043Zm-.023-.273.497-.043-.497.043Zm.013.262.352-.355-.352-.354-.353.354.353.355ZM9.278 6.393l-.054.498.238.026.17-.17-.354-.354ZM9 6.387l.033.5-.033-.5Zm-2.356.156.033.5-.033-.5Zm5.332 5.344-.498-.023.498.023Zm.03-.66-.498-.023.499.023Zm.001-.009.499.024v-.004l-.499-.02Zm0 0-.498-.023v.004l.498.02Zm.082-1.761.499.023-.499-.023Zm.002-.121-.353-.355-.152.153.006.216.498-.014Zm1.974-1.984.353.354.353-.354-.353-.354-.353.354Zm-.01-.01.043-.5-1.365-.12.969.974.352-.355Zm.27.023.043-.5-.043.5Zm.25.022-.043.5.043-.5ZM11.16 3.956l-.497.043.497-.043Zm.542.48-.023-.272-.994.087.023.272.994-.087Zm-.86.387.01.01.706-.708-.01-.01-.706.708Zm-1.21 1.924 1.915-1.924-.705-.709-1.915 1.924.705.709Zm-.299-.853a2.091 2.091 0 0 0-.366-.007l.066 1c.065-.005.13-.003.192.004l.108-.997Zm-.366-.007-2.356.156.066 1 2.356-.156-.066-1Zm-2.356.156c-.941.063-1.37 1.21-.703 1.88l.705-.709a.1.1 0 0 1 .064-.17l-.066-1Zm-.703 1.88 4.222 4.242.706-.709-4.223-4.242-.705.71Zm4.222 4.242.706-.709-.706.709Zm0 0 .007.007.705-.71-.006-.006-.706.709Zm.007.007.465.466.705-.708-.465-.467-.705.709Zm.465.466c.674.678 1.828.229 1.872-.727l-.996-.047a.095.095 0 0 1-.018.055.106.106 0 0 1-.046.033.104.104 0 0 1-.056.007.093.093 0 0 1-.05-.03l-.706.71Zm1.872-.727.031-.66-.996-.047-.031.66.996.046Zm.031-.66v-.01l-.996-.046v.009l.996.047Zm0-.013-.996-.04.997.04Zm0 .004.083-1.762-.997-.047-.082 1.762.997.046Zm.083-1.762c.002-.053.003-.106.001-.158l-.997.028v.083l.996.047Zm1.124-2.482L11.737 8.98l.705.71 1.975-1.985-.706-.708Zm-.01.698.01.01.706-.708-.01-.011-.706.709Zm.666-.83-.27-.024-.087.998.27.024.087-.998Zm.25.022-.25-.022-.086.998.25.022.087-.998Zm-.158.341a.2.2 0 0 1 .159-.341l-.087.998c.742.065 1.16-.836.634-1.366l-.706.709Zm-.178-.179.178.179.706-.709-.178-.178-.706.708Zm-.625-.627.625.627.706-.708-.625-.628-.706.709Zm-.018-.02.018.02.706-.71-.019-.018-.705.709Zm-.184-.184.184.185.705-.71-.183-.183-.706.708Zm-1.133-1.138 1.133 1.138.706-.708-1.133-1.139-.706.71Zm-.183-.184.183.184.706-.709-.184-.184-.705.709Zm-.02-.02.02.02.705-.709-.019-.019-.705.709Zm-.624-.627.625.628.705-.709-.625-.628-.705.709Zm-.178-.179.178.179.705-.709-.178-.178-.705.708Zm.34-.159a.2.2 0 0 1-.34.16l.705-.71c-.526-.528-1.424-.108-1.36.637l.995-.087Zm.022.252-.022-.252-.994.087.022.252.994-.087Z"
+                ></path>
+                <path
+                  fill="currentColor"
+                  fillRule="evenodd"
+                  stroke="currentColor"
+                  strokeWidth="0.5"
+                  d="M6.674 11.13 7.5 12l-2.665 2.166c-.26.185-.578-.138-.394-.4l2.233-2.637Z"
+                  clipRule="evenodd"
+                ></path>
+              </svg>
+              고정된 유저 메시지
+            </span>
+            <span id="chzzk-plus-new-message-dot">•</span>
+          </div>
+          <div className="live_chatting_fixed_mission_folded_button__bBWS2">
+            <svg
+              width="22"
+              height="22"
+              viewBox="0 0 22 22"
+              fill="none"
+              xmlns="http://www.w3.org/2000/svg"
+              style={{ transform: isOpen ? "rotate(180deg)" : "none" }}
+            >
+              <path
+                d="M7 9L11 13L15 9"
+                stroke="currentColor"
+                strokeWidth="2"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              ></path>
+            </svg>
+          </div>
+        </div>
+        <div ref={pinListRef} className="czp-message-pin-list">
+          {!hasMessages && (
+            <div id="chzzk-plus-message-pin-empty-message">
+              메시지가 없습니다
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/constants/class.ts
+++ b/src/constants/class.ts
@@ -25,6 +25,7 @@ export const STREAMER_MENU = ".navigator_item__qXlq9";
 
 // 채팅 부모
 export const CHAT_CONTAINER = ".live_chatting_list_wrapper__a5XTV";
+export const CHAT_ITEM = ".live_chatting_list_item__0SGhw";
 export const CHAT_NAME = ".name_text__yQG50";
 export const CHAT_CONTENT = ".live_chatting_message_text__DyleH";
 export const CHEEZE_CHAT = ".live_chatting_list_donation__Fy6Vz";
@@ -37,6 +38,9 @@ export const CHEEZE_RANKING_CHAT = ".live_chatting_ranking_container__RVHvS";
 export const LIVE_INFORMATION_HEAD = "video_information_row__HrQ0z";
 export const VIDEO_BUTTONS = ".pzp-pc__bottom-buttons-right";
 export const NAVIGATOR_BUTTON = ".navigator_button__BbAEb"; //팔로우 채널에 2개,추천 채널에 2개 있음. 각각 새로고침,접기
+export const USER_POPUP_CONTENTS = ".live_chatting_popup_profile_list__-AYwN";
+export const USER_POPUP_NAME =
+  "span.live_chatting_popup_profile_wrapper__Tcu6x > strong > span > span";
 
 // 채팅
 export const CHATTING_TOOLS = ".live_chatting_input_tools__OPA1R";

--- a/src/constants/storage.ts
+++ b/src/constants/storage.ts
@@ -62,3 +62,9 @@ export const RECORD_ENABLE = "czp-record-enable";
 
 // 자동 넓은 화면
 export const AUTO_WIDE_MODE = "czp-auto-wide";
+
+// 메시지 고정 유저 리스트
+export const MESSAGE_PIN_USERS = "czp-message-pin-users";
+
+// 메시지 고정 여부
+export const MESSAGE_PIN_ENABLE = "czp-message-pin-enable";

--- a/src/content.tsx
+++ b/src/content.tsx
@@ -26,14 +26,19 @@ const waitingSPALoaded = setInterval(() => {
      * /live 페이지에 editLivePage()를 호출하는 것 처럼 global 이 아닌 상황에는 이에 맞게 재호출 해줘야함
      * 중복되어 event나 element를 추가할 수 있으니 id 확인 등으로 재생성 방지해야함
      */
+    let lastUrl = location.href;
     const pageChangeOb = new MutationObserver(() => {
-      editGlobalPage();
-      editLivePage();
-      editLiveListPage();
-      editCategoryPage();
-      editVideoPage();
+      if (location.href !== lastUrl) {
+        lastUrl = location.href;
+        editGlobalPage();
+        editLivePage();
+        editLiveListPage();
+        editCategoryPage();
+        editVideoPage();
+      }
     });
-    pageChangeOb.observe(document.head, { subtree: true, childList: true });
+
+    pageChangeOb.observe(document, { subtree: true, childList: true });
 
     /**
      * [주의]

--- a/src/feature/chat.ts
+++ b/src/feature/chat.ts
@@ -1,4 +1,4 @@
-import { waitingElement } from "../utils/dom";
+import { createReactElement, waitingElement } from "../utils/dom";
 import {
   BLIND_CHAT,
   CHAT_CONTAINER,
@@ -17,8 +17,11 @@ import {
   CHAT_TEXT_COLOR,
   CHEEZE_RANKING_REMOVER,
   CHEEZE_REMOVER,
+  MESSAGE_PIN_ENABLE,
   SUBSCRIBE_REMOVER,
 } from "../constants/storage";
+import PinnedMessageBox from "../components/pinnedMessageBox/PinnedMessageBox";
+import { chatObserve, userPopupObserve } from "../utils/observe";
 
 export async function chatSetting(): Promise<void> {
   await waitingElement(CHAT_CONTAINER);
@@ -32,6 +35,7 @@ export async function chatSetting(): Promise<void> {
       BLIND_REMOVER,
       SUBSCRIBE_REMOVER,
       CHEEZE_RANKING_REMOVER,
+      MESSAGE_PIN_ENABLE,
     ],
     (res) => {
       const chatContainer = document.querySelector(CHAT_CONTAINER);
@@ -91,6 +95,35 @@ export async function chatSetting(): Promise<void> {
 
           style.innerHTML = innerHtml;
           document.head.appendChild(style);
+        }
+
+        //유저 메시지 고정 기능 추가
+        if (
+          res[MESSAGE_PIN_ENABLE] &&
+          !document.getElementById("chzzk-plus-message-pin")
+        ) {
+          userPopupObserve();
+          chatObserve();
+
+          //고정된 메시지 박스 추가
+          const fixedList = document.querySelector(
+            ".live_chatting_list_fixed__Wy3TT"
+          );
+          if (fixedList) {
+            const container = document.createElement("div");
+            fixedList.appendChild(container);
+            createReactElement(container, PinnedMessageBox);
+          } else {
+            const wrapper = document.createElement("div");
+            wrapper.className = "live_chatting_list_fixed__Wy3TT";
+            const fixedContainer = document.querySelector(
+              ".live_chatting_list_exist_fixed_message__2EP21"
+            );
+            fixedContainer?.appendChild(wrapper);
+            const container = document.createElement("div");
+            wrapper.appendChild(container);
+            createReactElement(container, PinnedMessageBox);
+          }
         }
       }
     }

--- a/src/page/global.ts
+++ b/src/page/global.ts
@@ -15,11 +15,10 @@ export const editGlobalPage = () => {
     $global.id = "chzzk-plus-global";
     document.body.appendChild($global);
     createReactElement($global, Global);
-
-    chatSetting();
   }
 
   previewSetting();
+  chatSetting();
 
   log("GLOBAL PAGE 설정");
 };

--- a/src/utils/observe.ts
+++ b/src/utils/observe.ts
@@ -1,0 +1,83 @@
+import { MESSAGE_PIN_USERS } from "../constants/storage";
+import { CHAT_CONTAINER, CHAT_NAME } from "../constants/class";
+import { createReactElement, waitingElement } from "./dom";
+import { USER_POPUP_CONTENTS } from "../constants/class";
+import UserPinButton from "../components/button/UserPinButton/UserPinButton";
+
+export const userPopupObserve = () => {
+  const userPopupOb = new MutationObserver(async () => {
+    await waitingElement(USER_POPUP_CONTENTS);
+
+    const userPopupContents = document.querySelector(USER_POPUP_CONTENTS);
+    if (
+      userPopupContents &&
+      !document.getElementById("chzzk-plus-user-pin-btn")
+    ) {
+      const container = document.createElement("div");
+      userPopupContents.appendChild(container);
+      createReactElement(container, UserPinButton);
+    }
+  });
+
+  const chatContainer = document.querySelector(CHAT_CONTAINER);
+  if (chatContainer) {
+    userPopupOb.observe(chatContainer, {
+      subtree: true,
+      childList: true,
+    });
+  }
+};
+
+export const chatObserve = () => {
+  const chatOb = new MutationObserver((mutations) => {
+    mutations.forEach((mutation) => {
+      mutation.addedNodes.forEach((node: Node) => {
+        if (
+          !(node instanceof Element) ||
+          !node.classList.contains("live_chatting_list_item__0SGhw")
+        )
+          return;
+
+        const nameElement = node.querySelector(CHAT_NAME);
+        const pinListElement = document.querySelector(".czp-message-pin-list");
+
+        if (!nameElement || !pinListElement) return;
+
+        chrome.storage.local.get([MESSAGE_PIN_USERS], (res) => {
+          const pinnedUsers = res[MESSAGE_PIN_USERS] || [];
+
+          if (!pinnedUsers.includes(nameElement.textContent)) return;
+
+          const clonedChat = node.cloneNode(true);
+
+          // 고정된 메시지 관리
+          if (pinListElement.childElementCount >= 200) {
+            pinListElement.removeChild(pinListElement.firstElementChild!);
+          }
+          pinListElement.appendChild(clonedChat);
+
+          // 새 메시지 도트 표시
+          const pinList = document.querySelector(".czp-message-pin-list");
+          const newMessageDot = document.getElementById(
+            "chzzk-plus-new-message-dot"
+          );
+          if (
+            newMessageDot &&
+            pinList &&
+            window.getComputedStyle(pinList).display === "none"
+          ) {
+            newMessageDot.style.display = "inline";
+          }
+        });
+      });
+    });
+  });
+
+  const chatContainer = document.querySelector(CHAT_CONTAINER);
+  if (chatContainer) {
+    chatOb.observe(chatContainer, {
+      subtree: true,
+      childList: true,
+    });
+  }
+};


### PR DESCRIPTION
### 개요
특정 유저의 채팅을 고정하는 기능입니다.

### 변경 사항
- 채팅에 '고정된 유저 메시지' 박스를 추가합니다.
- 유저 정보 팝업에 '유저 메시지 고정' 버튼을 추가합니다.
- 고정된 사용자의 메시지가 '고정된 유저 메시지' 박스에 추가됩니다.
- 확장프로그램 설정에서 기능 온오프/ 유저 리스트를 편집할 수 있습니다.

### 스크린샷
<img width="1439" alt="image" src="https://github.com/user-attachments/assets/ffa4c3ae-4ec3-4846-8a97-650838cb090a">

![image](https://github.com/user-attachments/assets/8326de2e-3f0e-4b12-9ceb-589cf46d33c9)


