### PR TITLE
feat : #54/자동 넓은 화면

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,6 +9,7 @@ import List from "./components/List/List";
 
 import {
   AUDIO_COMPRESSOR,
+  AUTO_WIDE_MODE,
   BLIND_REMOVER,
   BLOCKED_STREAMER,
   CHAT_COLOR_OPTIONS,
@@ -163,6 +164,13 @@ function App() {
           <Checkbox id={BLIND_REMOVER}>
             <div className="menu">
               <p className="menu-title">블라인드 챗 완전 제거 *</p>
+              <p className="menu-desc">새로고침 후 적용</p>
+            </div>
+          </Checkbox>
+
+          <Checkbox id={AUTO_WIDE_MODE}>
+            <div className="menu">
+              <p className="menu-title">자동 넓은 화면 *</p>
               <p className="menu-desc">새로고침 후 적용</p>
             </div>
           </Checkbox>

--- a/src/feature/chat.ts
+++ b/src/feature/chat.ts
@@ -24,9 +24,7 @@ import PinnedMessageBox from "../components/pinnedMessageBox/PinnedMessageBox";
 import { chatObserve, userPopupObserve } from "../utils/observe";
 
 export async function chatSetting(): Promise<void> {
-  await waitingElement(CHAT_CONTAINER);
-
-  // Feat: 채팅 색상, 치즈 제거 ===============================================================
+  const chatContainer = await waitingElement(CHAT_CONTAINER);
   chrome.storage.local.get(
     [
       CHAT_COLOR_THEME,
@@ -37,9 +35,7 @@ export async function chatSetting(): Promise<void> {
       CHEEZE_RANKING_REMOVER,
       MESSAGE_PIN_ENABLE,
     ],
-    (res) => {
-      const chatContainer = document.querySelector(CHAT_CONTAINER);
-
+    async (res) => {
       if (chatContainer) {
         // 치즈 제거 활성화
         if (res[CHEEZE_REMOVER]) {
@@ -98,10 +94,7 @@ export async function chatSetting(): Promise<void> {
         }
 
         //유저 메시지 고정 기능 추가
-        if (
-          res[MESSAGE_PIN_ENABLE] &&
-          !document.getElementById("chzzk-plus-message-pin")
-        ) {
+        if (res[MESSAGE_PIN_ENABLE]) {
           userPopupObserve();
           chatObserve();
 
@@ -116,13 +109,15 @@ export async function chatSetting(): Promise<void> {
           } else {
             const wrapper = document.createElement("div");
             wrapper.className = "live_chatting_list_fixed__Wy3TT";
-            const fixedContainer = document.querySelector(
-              ".live_chatting_list_exist_fixed_message__2EP21"
+            const chatListContainer = await waitingElement(
+              ".live_chatting_list_container__vwsbZ"
             );
-            fixedContainer?.appendChild(wrapper);
-            const container = document.createElement("div");
-            wrapper.appendChild(container);
-            createReactElement(container, PinnedMessageBox);
+            if (chatListContainer) {
+              chatListContainer.appendChild(wrapper);
+              const container = document.createElement("div");
+              wrapper.appendChild(container);
+              createReactElement(container, PinnedMessageBox);
+            }
           }
         }
       }

--- a/src/utils/dom.ts
+++ b/src/utils/dom.ts
@@ -8,15 +8,18 @@ export const createReactElement = (
   ReactDOM.createRoot(root).render(React.createElement(element));
 };
 
-export async function waitingElement(selector: string): Promise<HTMLElement> {
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  return await new Promise((resolve, _reject) => {
-    const interval = setInterval(() => {
-      const element = document.querySelector(selector);
-      if (element !== null) {
-        clearInterval(interval);
-        resolve(element as HTMLElement);
-      }
-    }, 500);
-  });
+export async function waitingElement(
+  selector: string,
+  timeout: number = 5000
+): Promise<HTMLElement | null> {
+  const startTime = Date.now();
+  while (document.querySelector(selector) === null) {
+    // 타임아웃
+    if (Date.now() - startTime >= timeout) {
+      return null;
+    }
+    await new Promise((resolve) => requestAnimationFrame(resolve));
+  }
+
+  return document.querySelector(selector) as HTMLElement;
 }

--- a/src/utils/observe.ts
+++ b/src/utils/observe.ts
@@ -1,10 +1,10 @@
 import { MESSAGE_PIN_USERS } from "../constants/storage";
 import { CHAT_CONTAINER, CHAT_NAME } from "../constants/class";
-import { createReactElement } from "./dom";
+import { createReactElement, waitingElement } from "./dom";
 import { USER_POPUP_CONTENTS } from "../constants/class";
 import UserPinButton from "../components/button/UserPinButton/UserPinButton";
 
-export const userPopupObserve = () => {
+export const userPopupObserve = async () => {
   const userPopupOb = new MutationObserver((mutations) => {
     mutations.forEach((mutation) => {
       mutation.addedNodes.forEach((node: Node) => {
@@ -31,7 +31,7 @@ export const userPopupObserve = () => {
     });
   });
 
-  const chatContainer = document.querySelector(CHAT_CONTAINER);
+  const chatContainer = await waitingElement(CHAT_CONTAINER);
   if (chatContainer) {
     userPopupOb.observe(chatContainer, {
       subtree: true,
@@ -40,7 +40,7 @@ export const userPopupObserve = () => {
   }
 };
 
-export const chatObserve = () => {
+export const chatObserve = async () => {
   const chatOb = new MutationObserver((mutations) => {
     mutations.forEach((mutation) => {
       mutation.addedNodes.forEach((node: Node) => {
@@ -85,7 +85,7 @@ export const chatObserve = () => {
     });
   });
 
-  const chatContainer = document.querySelector(CHAT_CONTAINER);
+  const chatContainer = await waitingElement(CHAT_CONTAINER);
   if (chatContainer) {
     chatOb.observe(chatContainer, {
       subtree: true,


### PR DESCRIPTION
## 개요
- 방송 진입시 자동으로 '넓은 화면'를 적용할 수 있습니다.

## 변경사항
- 자동으로 넓은 화면 기능에 대한 온오프 체크박스를 추가했습니다 (App.tsx)
- `editLivePage` 수정
	- 방송 화면 진입시 넓은 화면 버튼 클릭하는 코드 추가
	- 처음 진입한 방송이 아닌 좌측의 메뉴를 통해 진입한 방송화면일경우 자동 넓은화면 기능이 작동하지 않고 '저장소'를 비롯한 여러가지 버튼이 나오지 않는 문제
		- 페이지 로딩과 코드 실행속도의 차이로 인해 요소를 감지하지 못하는 이슈로 파악되어 `watingElement`를 이용하는 방식으로 수정하였습니다.
- dom.ts의 `watiingElement` 함수 수정
	- setTimeout을 이용해서 구현하는 방식에서 requestAnimationFrame를 사용하여 브라우저의 다음 리페인트 시점에 체크를 하는 방식으로 수정하였습니다. 이제 더 빠르고 효율적으로 작동합니다.
		- 다른 확장프로그램 코드를 참고하였으며, 의도된 구현인경우 다시 원상복구 하도록 하겠습니다. 
	- 해당 함수를 수정하면서 속도가 빨라져 기존 메시지 고정 기능에 버그가 발견되어 코드를 수정하였습니다. (chat.ts, observer.ts)

---


- Resolves #54 