### PR TITLE
feat: 라이브 방송 채팅 중 이모티콘 팝업 상 검색과 이모티콘 태그 기능 추가 (#95)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -28,6 +28,7 @@ import {
   CHAT_BADGE_REMOVER,
   CHAT_COLOR_OPTIONS,
   CHAT_COLOR_THEME,
+  CHAT_EMOJI_SEARCH_ENABLE,
   CHAT_NAME_COLOR,
   CHAT_SIZE,
   CHAT_SIZE_OPTIONS,
@@ -417,6 +418,13 @@ function App() {
               <div className="menu">
                 <p className="menu-title">채팅 타임스탬프</p>
                 <p className="menu-desc">채팅 옆에 도착 시각 표시</p>
+              </div>
+            </Checkbox>
+
+            <Checkbox id={CHAT_EMOJI_SEARCH_ENABLE}>
+              <div className="menu">
+                <p className="menu-title">이모티콘 검색</p>
+                <p className="menu-desc">이모티콘 팝업 상단에 검색창 표시</p>
               </div>
             </Checkbox>
 

--- a/src/background.ts
+++ b/src/background.ts
@@ -8,6 +8,7 @@ import {
   AUDIO_COMPRESSOR,
   AUDIO_COMPRESSOR_AUTO,
   FAST_BUTTON,
+  CHAT_EMOJI_SEARCH_ENABLE,
 } from './constants/storage';
 
 const defaultValues: Record<string, unknown> = {
@@ -20,6 +21,7 @@ const defaultValues: Record<string, unknown> = {
   [AUDIO_COMPRESSOR]: true,
   [AUDIO_COMPRESSOR_AUTO]: true,
   [FAST_BUTTON]: true,
+  [CHAT_EMOJI_SEARCH_ENABLE]: true,
 };
 
 chrome.runtime.onMessage.addListener(message => {

--- a/src/components/ChatEmojiSearch/ChatEmojiSearch.css
+++ b/src/components/ChatEmojiSearch/ChatEmojiSearch.css
@@ -39,23 +39,23 @@
   border: none;
   border-radius: 4px;
   background: transparent;
-  color: rgba(160, 160, 160, 0.9);
+  color: var(--color-content-02);
   cursor: pointer;
   transform: translateY(-50%);
 }
 
 .czp-emoji-search-tag-btn:hover {
   color: #2cbf8a;
-  background: rgba(255, 255, 255, 0.08);
+  background: rgba(var(--color-border-01-rgb), 0.08);
 }
 
 .czp-emoji-search-input {
   box-sizing: border-box;
   width: 100%;
   padding: 6px 30px 6px 10px; /* 우측은 태그 버튼 자리 */
-  border: 1px solid rgba(255, 255, 255, 0.14);
+  border: 1px solid rgba(var(--color-border-01-rgb), 0.2);
   border-radius: 6px;
-  background: rgba(255, 255, 255, 0.06);
+  background: var(--color-bg-03, rgba(255, 255, 255, 0.06));
   color: inherit;
   font-size: 13px;
   outline: none;
@@ -66,7 +66,7 @@
 }
 
 .czp-emoji-search-input::placeholder {
-  color: rgba(160, 160, 160, 0.8);
+  color: var(--color-content-02);
 }
 
 /* _list_2zr6f_152 */
@@ -98,7 +98,7 @@
 
 .czp-emoji-search-item:hover,
 .czp-emoji-search-item--selected {
-  background: rgba(255, 255, 255, 0.12);
+  background: rgba(var(--color-border-01-rgb), 0.12);
 }
 
 .czp-emoji-search-item img {
@@ -110,7 +110,7 @@
 .czp-emoji-search-empty {
   grid-column: 1 / -1;
   padding: 8px 0;
-  color: rgba(160, 160, 160, 0.9);
+  color: var(--color-content-02);
   font-size: 12px;
   text-align: center;
 }

--- a/src/components/ChatEmojiSearch/ChatEmojiSearch.css
+++ b/src/components/ChatEmojiSearch/ChatEmojiSearch.css
@@ -84,17 +84,16 @@
 
 /* _item_2zr6f_167 */
 .czp-emoji-search-item {
-  width: 40px;
-  height: 40px;
-  /* display: flex;
+  display: flex;
   align-items: center;
   justify-content: center;
-  width: 100%;
+  width: 40px;
+  height: 40px;
   padding: 2px;
   border: none;
   border-radius: 6px;
   background: transparent;
-  cursor: pointer; */
+  cursor: pointer;
 }
 
 .czp-emoji-search-item:hover,

--- a/src/components/ChatEmojiSearch/ChatEmojiSearch.css
+++ b/src/components/ChatEmojiSearch/ChatEmojiSearch.css
@@ -1,5 +1,6 @@
-.czp-emoji-search {
-  padding: 8px 10px 4px;
+/* 팝업 다이얼로그 */
+.czp-emoji-search-popup-expanded {
+  height: 500px !important;
 }
 
 /* _subtitle_2zr6f_124 */

--- a/src/components/ChatEmojiSearch/ChatEmojiSearch.css
+++ b/src/components/ChatEmojiSearch/ChatEmojiSearch.css
@@ -72,7 +72,8 @@
   cursor: pointer; */
 }
 
-.czp-emoji-search-item:hover {
+.czp-emoji-search-item:hover,
+.czp-emoji-search-item--selected {
   background: rgba(255, 255, 255, 0.12);
 }
 

--- a/src/components/ChatEmojiSearch/ChatEmojiSearch.css
+++ b/src/components/ChatEmojiSearch/ChatEmojiSearch.css
@@ -22,12 +22,37 @@
   right: 12px;
 }
 
+.czp-emoji-search-input-wrap {
+  position: relative;
+  margin-top: 10px;
+  margin-bottom: 10px;
+}
+
+.czp-emoji-search-tag-btn {
+  position: absolute;
+  top: 50%;
+  right: 6px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 4px;
+  border: none;
+  border-radius: 4px;
+  background: transparent;
+  color: rgba(160, 160, 160, 0.9);
+  cursor: pointer;
+  transform: translateY(-50%);
+}
+
+.czp-emoji-search-tag-btn:hover {
+  color: #2cbf8a;
+  background: rgba(255, 255, 255, 0.08);
+}
+
 .czp-emoji-search-input {
   box-sizing: border-box;
   width: 100%;
-  padding: 6px 10px;
-  margin-top: 10px;
-  margin-bottom: 10px;
+  padding: 6px 30px 6px 10px; /* 우측은 태그 버튼 자리 */
   border: 1px solid rgba(255, 255, 255, 0.14);
   border-radius: 6px;
   background: rgba(255, 255, 255, 0.06);

--- a/src/components/ChatEmojiSearch/ChatEmojiSearch.css
+++ b/src/components/ChatEmojiSearch/ChatEmojiSearch.css
@@ -1,0 +1,91 @@
+.czp-emoji-search {
+  padding: 8px 10px 4px;
+}
+
+/* _subtitle_2zr6f_124 */
+.czp-emoji-search-header {
+  word-break: break-all;
+  word-wrap: break-word;
+  z-index: 10;
+  background-color: var(--Surface-Neutral-Subtle);
+  color: var(--Content-Neutral-Cool-Strong);
+  border-radius: 6px;
+  align-items: center;
+  padding: 3px 3px 3px 8px;
+  font-size: 12px;
+  font-weight: 700;
+  line-height: 20px;
+  display: flex;
+  position: sticky;
+  top: -1px;
+  left: 12px;
+  right: 12px;
+}
+
+.czp-emoji-search-input {
+  box-sizing: border-box;
+  width: 100%;
+  padding: 6px 10px;
+  margin-top: 10px;
+  margin-bottom: 10px;
+  border: 1px solid rgba(255, 255, 255, 0.14);
+  border-radius: 6px;
+  background: rgba(255, 255, 255, 0.06);
+  color: inherit;
+  font-size: 13px;
+  outline: none;
+}
+
+.czp-emoji-search-input:focus {
+  border-color: #2cbf8a;
+}
+
+.czp-emoji-search-input::placeholder {
+  color: rgba(160, 160, 160, 0.8);
+}
+
+/* _list_2zr6f_152 */
+.czp-emoji-search-results {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(36px, 1fr));
+  column-gap: 5px;
+  gap: 6px 0;
+  max-height: 160px;
+  margin: 8px 0;
+  padding: 0 5px;
+  overflow-y: auto;
+  list-style: none;
+}
+
+/* _item_2zr6f_167 */
+.czp-emoji-search-item {
+  width: 40px;
+  height: 40px;
+  /* display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  padding: 2px;
+  border: none;
+  border-radius: 6px;
+  background: transparent;
+  cursor: pointer; */
+}
+
+.czp-emoji-search-item:hover {
+  background: rgba(255, 255, 255, 0.12);
+}
+
+.czp-emoji-search-item img {
+  width: 30px;
+  height: 30px;
+  object-fit: contain;
+}
+
+.czp-emoji-search-empty {
+  grid-column: 1 / -1;
+  padding: 8px 0;
+  color: rgba(160, 160, 160, 0.9);
+  font-size: 12px;
+  text-align: center;
+}

--- a/src/components/ChatEmojiSearch/ChatEmojiSearch.tsx
+++ b/src/components/ChatEmojiSearch/ChatEmojiSearch.tsx
@@ -157,6 +157,7 @@ export default function ChatEmojiSearch() {
 
     if (results.length === 0) return;
     if (e.metaKey || e.ctrlKey || e.altKey) return; // OS 단축키 조합은 건드리지 않음
+    if (e.nativeEvent.isComposing) return; // 한글 IME 조합 중 키는 조합 로직에 양보 (Enter 이중 발화 방지)
 
     // 선택 없이 엔터 시 기본 동작 허용
     if (e.key === 'Enter' && (selected < 0 || !results[selected])) return;

--- a/src/components/ChatEmojiSearch/ChatEmojiSearch.tsx
+++ b/src/components/ChatEmojiSearch/ChatEmojiSearch.tsx
@@ -143,39 +143,39 @@ export default function ChatEmojiSearch() {
     });
   };
 
+  // 키 → 선택 이동량.
+  const deltaByKey: Record<string, (e: React.KeyboardEvent) => number> = {
+    Tab: e => (e.shiftKey ? -1 : 1), // 포커스는 검색창에 유지한 채 선택만 이동
+    ArrowLeft: () => -1,
+    ArrowRight: () => 1,
+    ArrowUp: () => -getColumnCount(), // ↑↓ 이동량 = 현재 열 수
+    ArrowDown: () => getColumnCount(),
+  };
+
   const onKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
     // 치지직 전역 단축키(채팅 포커스 등)와 충돌 방지
-    e.stopPropagation();
 
     if (results.length === 0) return;
     if (e.metaKey || e.ctrlKey || e.altKey) return; // OS 단축키 조합은 건드리지 않음
 
-    if (e.key === 'Tab') {
-      // 포커스는 검색창에 유지한 채 선택만 순환 (Shift+Tab 역방향)
-      e.preventDefault();
-      const delta = e.shiftKey ? -1 : 1;
-      setSelected(prev => (prev + delta + results.length) % results.length);
-      return;
-    }
+    // 선택 없이 엔터 시 기본 동작 허용
+    if (e.key === 'Enter' && (selected < 0 || !results[selected])) return;
 
     // ←→ 는 선택이 활성화된 뒤에만 그리드 이동 (그 전에는 검색어 캐럿 이동에 양보)
-    if ((e.key === 'ArrowLeft' || e.key === 'ArrowRight') && selected >= 0) {
-      e.preventDefault();
-      moveSelection(e.key === 'ArrowRight' ? 1 : -1);
-      return;
-    }
+    if ((e.key === 'ArrowLeft' || e.key === 'ArrowRight') && selected < 0) return;
 
-    // ↑↓ 는 항상 그리드 이동 (한 줄 input 이라 캐럿 용도 없음). 이동량 = 현재 열 수
-    if (e.key === 'ArrowDown' || e.key === 'ArrowUp') {
-      e.preventDefault();
-      const columns = getColumnCount();
-      moveSelection(e.key === 'ArrowDown' ? columns : -columns);
-      return;
-    }
+    const isEnter = e.key === 'Enter';
+    const getDelta = deltaByKey[e.key];
+    // 처리 대상이 아닌 키는 기본 동작(문자 입력, Backspace 등)에 양보 — preventDefault 전에 판정해야 함
+    if (!isEnter && !getDelta) return;
 
-    if (e.key === 'Enter' && selected >= 0 && results[selected]) {
-      e.preventDefault();
+    e.stopPropagation();
+    e.preventDefault();
+
+    if (isEnter) {
       insertEmoji(results[selected]);
+    } else {
+      moveSelection(getDelta(e));
     }
   };
 
@@ -184,7 +184,7 @@ export default function ChatEmojiSearch() {
   };
 
   return (
-    <div>
+    <div className="czp-emoji-search">
       <strong className="czp-emoji-search-header">이모티콘 검색</strong>
       <div className="czp-emoji-search-input-wrap">
         <input

--- a/src/components/ChatEmojiSearch/ChatEmojiSearch.tsx
+++ b/src/components/ChatEmojiSearch/ChatEmojiSearch.tsx
@@ -1,6 +1,7 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { CHAT_EMOJI_AREA, CHAT_EMOJI_SEARCH_ROOT_CLASS, EMOJI_PACK_TAB_ID_PREFIX } from '../../constants/class';
 import { getChannelIDByUrl } from '../../utils/channel';
+import { dispatchMouseClickSequence } from '../../utils/dom';
 import './ChatEmojiSearch.css';
 
 // === emoji-packs API 응답 타입 (사용하는 필드만 선언) ===
@@ -75,14 +76,6 @@ const findNativeEmojiButton = (emojiId: string): HTMLButtonElement | null => {
   return matchedEmoji?.closest('button') ?? null;
 };
 
-// 팩 탭 버튼은 click 이 아니라 mousedown/mouseup 에 핸들러가 걸려 있어 click() 으로는 전환되지 않는다.
-// 실제 마우스 조작과 동일한 mousedown → mouseup 시퀀스를 디스패치한다. (실환경 검증됨)
-const dispatchMouseDownUp = ($el: HTMLElement): void => {
-  const base = { bubbles: true, cancelable: true, view: window, button: 0 };
-  $el.dispatchEvent(new MouseEvent('mousedown', { ...base, buttons: 1 }));
-  $el.dispatchEvent(new MouseEvent('mouseup', { ...base, buttons: 0 }));
-};
-
 /**
  * 네이티브 이모티콘 버튼에 click 을 디스패치해 치지직 자체 삽입 경로를 재사용한다.
  * 팩 탭 구조라 현재 탭에 없는 이모티콘은, 팩 탭(id: emoji_pack_id_{packId})을
@@ -99,7 +92,7 @@ const insertEmoji = async ({ emojiId, packId }: EmojiIndexItem): Promise<void> =
   // 2) 해당 팩 탭으로 전환 후 재시도
   const $tabBtn = document.getElementById(`${EMOJI_PACK_TAB_ID_PREFIX}${packId}`);
   if (!$tabBtn) return;
-  dispatchMouseDownUp($tabBtn);
+  dispatchMouseClickSequence($tabBtn);
 
   // 탭 전환 렌더링을 기다리며 재시도 (최대 1초)
   // waitingElement 는 셀렉터만 받아 우리 결과 img 를 구분할 수 없으므로, 제외 필터가 있는 finder 로 폴링한다.
@@ -118,6 +111,15 @@ export default function ChatEmojiSearch() {
   const [index, setIndex] = useState<EmojiIndexItem[]>([]);
   const [query, setQuery] = useState('');
   const [failed, setFailed] = useState(false);
+  // 키보드(Tab/방향키)로 선택된 결과 인덱스. -1 = 선택 없음
+  const [selected, setSelected] = useState(-1);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const gridRef = useRef<HTMLUListElement>(null);
+
+  // 마운트 = 팝업 열림 → 검색창 자동 포커스 (바로 타이핑 시작 가능)
+  useEffect(() => {
+    inputRef.current?.focus();
+  }, []);
 
   useEffect(() => {
     const channelId = getChannelIDByUrl(document.URL);
@@ -131,41 +133,104 @@ export default function ChatEmojiSearch() {
       .catch(() => setFailed(true));
   }, []);
 
+  // TODO: 태그 검색 - 현재는 치지직 API 에서 제공하는 emojiId, packName 으로만(휴먼리더블x) 검색 가능.
   const results = useMemo(() => {
     const q = query.trim().toLowerCase();
     if (!q) return [];
 
-    // TODO: 한글 초성 검색 (팩 이름 대상)
     return index
       .filter(e => e.emojiId.toLowerCase().includes(q) || e.packName.toLowerCase().includes(q))
       .slice(0, MAX_RESULTS);
   }, [query, index]);
 
+  // 검색어가 바뀌면 선택 초기화
+  useEffect(() => {
+    setSelected(-1);
+  }, [query]);
+
+  // 선택된 항목이 그리드 스크롤 밖이면 보이게
+  useEffect(() => {
+    if (selected < 0) return;
+    document.querySelector('.czp-emoji-search-item--selected')?.scrollIntoView({ block: 'nearest' });
+  }, [selected]);
+
+  // 그리드의 현재 열 수 (auto-fill 이라 컨테이너 폭에 따라 변함 → 키 입력 시점에 계산)
+  const getColumnCount = (): number => {
+    if (!gridRef.current) return 1;
+    return getComputedStyle(gridRef.current).gridTemplateColumns.split(' ').length;
+  };
+
+  // 선택 인덱스를 delta 만큼 이동 (범위는 clamp — Tab 순환과 달리 그리드 끝에서 멈추는 게 자연스러움)
+  const moveSelection = (delta: number): void => {
+    setSelected(prev => {
+      if (prev === -1) return delta > 0 ? 0 : results.length - 1; // 첫 진입
+      return Math.min(Math.max(prev + delta, 0), results.length - 1);
+    });
+  };
+
+  const onKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    // 치지직 전역 단축키(채팅 포커스 등)와 충돌 방지
+    e.stopPropagation();
+
+    if (results.length === 0) return;
+    if (e.metaKey || e.ctrlKey || e.altKey) return; // OS 단축키 조합은 건드리지 않음
+
+    if (e.key === 'Tab') {
+      // 포커스는 검색창에 유지한 채 선택만 순환 (Shift+Tab 역방향)
+      e.preventDefault();
+      const delta = e.shiftKey ? -1 : 1;
+      setSelected(prev => (prev + delta + results.length) % results.length);
+      return;
+    }
+
+    // ←→ 는 선택이 활성화된 뒤에만 그리드 이동 (그 전에는 검색어 캐럿 이동에 양보)
+    if ((e.key === 'ArrowLeft' || e.key === 'ArrowRight') && selected >= 0) {
+      e.preventDefault();
+      moveSelection(e.key === 'ArrowRight' ? 1 : -1);
+      return;
+    }
+
+    // ↑↓ 는 항상 그리드 이동 (한 줄 input 이라 캐럿 용도 없음). 이동량 = 현재 열 수
+    if (e.key === 'ArrowDown' || e.key === 'ArrowUp') {
+      e.preventDefault();
+      const columns = getColumnCount();
+      moveSelection(e.key === 'ArrowDown' ? columns : -columns);
+      return;
+    }
+
+    if (e.key === 'Enter' && selected >= 0 && results[selected]) {
+      e.preventDefault();
+      insertEmoji(results[selected]);
+    }
+  };
+
   return (
     <div>
       <strong className="czp-emoji-search-header">이모티콘 검색</strong>
       <input
+        ref={inputRef}
         className="czp-emoji-search-input"
         type="text"
         placeholder={failed ? '이모티콘 목록을 불러오지 못했어요' : '이모티콘 검색'}
         disabled={failed}
         value={query}
         onChange={e => setQuery(e.target.value)}
-        // 치지직 전역 단축키(채팅 포커스 등)와 충돌 방지
-        onKeyDown={e => e.stopPropagation()}
+        onKeyDown={onKeyDown}
       />
       {query.trim() !== '' && (
-        <ul className="czp-emoji-search-results">
+        <ul ref={gridRef} className="czp-emoji-search-results">
           {results.length === 0 ? (
             <li className="czp-emoji-search-empty">검색 결과가 없어요</li>
           ) : (
-            results.map(e => (
+            results.map((e, i) => (
               <li key={e.emojiId}>
                 <button
                   type="button"
-                  className="czp-emoji-search-item"
+                  className={`czp-emoji-search-item${i === selected ? ' czp-emoji-search-item--selected' : ''}`}
                   title={`${e.emojiId} · ${e.packName}`}
                   onClick={() => insertEmoji(e)}
+                  // 버튼이 포커스를 뺏지 않게 → 검색창 포커스 유지, 클릭 후 Enter 재입력 방지
+                  onMouseDown={e => e.preventDefault()}
                 >
                   <img src={e.imageUrl} alt={`{:${e.emojiId}:}`} loading="lazy" />
                 </button>

--- a/src/components/ChatEmojiSearch/ChatEmojiSearch.tsx
+++ b/src/components/ChatEmojiSearch/ChatEmojiSearch.tsx
@@ -1,0 +1,179 @@
+import { useEffect, useMemo, useState } from 'react';
+import { CHAT_EMOJI_AREA, CHAT_EMOJI_SEARCH_ROOT_CLASS, EMOJI_PACK_TAB_ID_PREFIX } from '../../constants/class';
+import { getChannelIDByUrl } from '../../utils/channel';
+import './ChatEmojiSearch.css';
+
+// === emoji-packs API 응답 타입 (사용하는 필드만 선언) ===
+// API 를 사용한 fetch 는 EmojiSearch 에서만 사용되므로, 별도 api 모듈로 분리하지 않음
+type Emoji = {
+  emojiId: string;
+  imageUrl: string;
+};
+
+type EmojiPack = {
+  emojiPackId: string;
+  emojiPackName: string;
+  emojiPackLocked: boolean;
+  emojiTier2Locked?: boolean;
+  emojis: Emoji[];
+  tier2Emojis?: Emoji[] | null;
+};
+
+type EmojiPacksContent = {
+  emojiPacks: EmojiPack[];
+  cheatKeyEmojiPacks: EmojiPack[];
+  subscriptionEmojiPacks: EmojiPack[];
+};
+
+type EmojiIndexItem = {
+  emojiId: string;
+  imageUrl: string;
+  packId: string;
+  packName: string;
+};
+
+const MAX_RESULTS = 60;
+
+/**
+ * emoji-packs API 로 검색 인덱스를 만든다.
+ * - 3개 팩 배열(기본/치트키/구독)을 병합
+ * - 잠긴 팩(미구독), tier2 잠금 이모티콘은 사용할 수 없으므로 제외
+ */
+const fetchEmojiIndex = async (channelId: string): Promise<EmojiIndexItem[]> => {
+  const res = await fetch(`https://api.chzzk.naver.com/service/v1/channels/${channelId}/emoji-packs`, {
+    credentials: 'include',
+  });
+  if (!res.ok) throw new Error(`emoji-packs HTTP ${res.status}`);
+
+  const { content } = (await res.json()) as { content: EmojiPacksContent };
+  const packs = [...content.emojiPacks, ...content.cheatKeyEmojiPacks, ...content.subscriptionEmojiPacks];
+
+  return packs.flatMap(pack => {
+    if (pack.emojiPackLocked) return [];
+
+    const lockedTier2 = new Set((pack.emojiTier2Locked ? (pack.tier2Emojis ?? []) : []).map(e => e.emojiId));
+
+    return pack.emojis
+      .filter(e => !lockedTier2.has(e.emojiId))
+      .map(e => ({
+        emojiId: e.emojiId,
+        imageUrl: e.imageUrl,
+        packId: pack.emojiPackId,
+        packName: pack.emojiPackName,
+      }));
+  });
+};
+
+// 팝업(#emoji_area) 안에서 해당 이모티콘의 네이티브 버튼을 찾는다.
+// 우리 검색 UI 도 #emoji_area 안에 마운트되고 결과 img 의 alt 포맷이 동일하므로,
+// 우리 루트(CHAT_EMOJI_SEARCH_ROOT_CLASS) 하위는 반드시 제외한다. (자기 클릭 → 무한 재귀 방지)
+const findNativeEmojiButton = (emojiId: string): HTMLButtonElement | null => {
+  const areaEmojis = [...document.querySelectorAll<HTMLImageElement>(`${CHAT_EMOJI_AREA} button img`)];
+
+  const listedEmojis = areaEmojis.filter($img => !$img.closest(`.${CHAT_EMOJI_SEARCH_ROOT_CLASS}`));
+  const matchedEmoji = listedEmojis.find($img => $img.alt === `{:${emojiId}:}`);
+  return matchedEmoji?.closest('button') ?? null;
+};
+
+// 팩 탭 버튼은 click 이 아니라 mousedown/mouseup 에 핸들러가 걸려 있어 click() 으로는 전환되지 않는다.
+// 실제 마우스 조작과 동일한 mousedown → mouseup 시퀀스를 디스패치한다. (실환경 검증됨)
+const dispatchMouseDownUp = ($el: HTMLElement): void => {
+  const base = { bubbles: true, cancelable: true, view: window, button: 0 };
+  $el.dispatchEvent(new MouseEvent('mousedown', { ...base, buttons: 1 }));
+  $el.dispatchEvent(new MouseEvent('mouseup', { ...base, buttons: 0 }));
+};
+
+/**
+ * 네이티브 이모티콘 버튼에 click 을 디스패치해 치지직 자체 삽입 경로를 재사용한다.
+ * 팩 탭 구조라 현재 탭에 없는 이모티콘은, 팩 탭(id: emoji_pack_id_{packId})을
+ * 먼저 전환한 뒤 버튼이 렌더링되기를 기다렸다가 클릭한다.
+ */
+const insertEmoji = async ({ emojiId, packId }: EmojiIndexItem): Promise<void> => {
+  // 1) 현재 탭에 이미 렌더링돼 있으면 바로 클릭
+  const $btn = findNativeEmojiButton(emojiId);
+  if ($btn) {
+    $btn.click();
+    return;
+  }
+
+  // 2) 해당 팩 탭으로 전환 후 재시도
+  const $tabBtn = document.getElementById(`${EMOJI_PACK_TAB_ID_PREFIX}${packId}`);
+  if (!$tabBtn) return;
+  dispatchMouseDownUp($tabBtn);
+
+  // 탭 전환 렌더링을 기다리며 재시도 (최대 1초)
+  // waitingElement 는 셀렉터만 받아 우리 결과 img 를 구분할 수 없으므로, 제외 필터가 있는 finder 로 폴링한다.
+  for (let i = 0; i < 20; i++) {
+    await new Promise(resolve => setTimeout(resolve, 50));
+
+    const $retryBtn = findNativeEmojiButton(emojiId);
+    if ($retryBtn) {
+      $retryBtn.click();
+      return;
+    }
+  }
+};
+
+export default function ChatEmojiSearch() {
+  const [index, setIndex] = useState<EmojiIndexItem[]>([]);
+  const [query, setQuery] = useState('');
+  const [failed, setFailed] = useState(false);
+
+  useEffect(() => {
+    const channelId = getChannelIDByUrl(document.URL);
+    if (!channelId) {
+      setFailed(true);
+      return;
+    }
+
+    fetchEmojiIndex(channelId)
+      .then(setIndex)
+      .catch(() => setFailed(true));
+  }, []);
+
+  const results = useMemo(() => {
+    const q = query.trim().toLowerCase();
+    if (!q) return [];
+
+    // TODO: 한글 초성 검색 (팩 이름 대상)
+    return index
+      .filter(e => e.emojiId.toLowerCase().includes(q) || e.packName.toLowerCase().includes(q))
+      .slice(0, MAX_RESULTS);
+  }, [query, index]);
+
+  return (
+    <div>
+      <strong className="czp-emoji-search-header">이모티콘 검색</strong>
+      <input
+        className="czp-emoji-search-input"
+        type="text"
+        placeholder={failed ? '이모티콘 목록을 불러오지 못했어요' : '이모티콘 검색'}
+        disabled={failed}
+        value={query}
+        onChange={e => setQuery(e.target.value)}
+        // 치지직 전역 단축키(채팅 포커스 등)와 충돌 방지
+        onKeyDown={e => e.stopPropagation()}
+      />
+      {query.trim() !== '' && (
+        <ul className="czp-emoji-search-results">
+          {results.length === 0 ? (
+            <li className="czp-emoji-search-empty">검색 결과가 없어요</li>
+          ) : (
+            results.map(e => (
+              <li key={e.emojiId}>
+                <button
+                  type="button"
+                  className="czp-emoji-search-item"
+                  title={`${e.emojiId} · ${e.packName}`}
+                  onClick={() => insertEmoji(e)}
+                >
+                  <img src={e.imageUrl} alt={`{:${e.emojiId}:}`} loading="lazy" />
+                </button>
+              </li>
+            ))
+          )}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/src/components/ChatEmojiSearch/ChatEmojiSearch.tsx
+++ b/src/components/ChatEmojiSearch/ChatEmojiSearch.tsx
@@ -1,69 +1,12 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { CHAT_EMOJI_AREA, CHAT_EMOJI_SEARCH_ROOT_CLASS, EMOJI_PACK_TAB_ID_PREFIX } from '../../constants/class';
+import { CHAT_EMOJI_TAG_MODAL, CHAT_EMOJI_TAG_QUERY, CHAT_EMOJI_TAGS } from '../../constants/storage';
 import { getChannelIDByUrl } from '../../utils/channel';
 import { dispatchMouseClickSequence } from '../../utils/dom';
+import { getEmojiIndex, loadEmojiTags, type EmojiIndexItem, type EmojiTags } from '../../utils/emoji';
 import './ChatEmojiSearch.css';
 
-// === emoji-packs API 응답 타입 (사용하는 필드만 선언) ===
-// API 를 사용한 fetch 는 EmojiSearch 에서만 사용되므로, 별도 api 모듈로 분리하지 않음
-type Emoji = {
-  emojiId: string;
-  imageUrl: string;
-};
-
-type EmojiPack = {
-  emojiPackId: string;
-  emojiPackName: string;
-  emojiPackLocked: boolean;
-  emojiTier2Locked?: boolean;
-  emojis: Emoji[];
-  tier2Emojis?: Emoji[] | null;
-};
-
-type EmojiPacksContent = {
-  emojiPacks: EmojiPack[];
-  cheatKeyEmojiPacks: EmojiPack[];
-  subscriptionEmojiPacks: EmojiPack[];
-};
-
-type EmojiIndexItem = {
-  emojiId: string;
-  imageUrl: string;
-  packId: string;
-  packName: string;
-};
-
 const MAX_RESULTS = 60;
-
-/**
- * emoji-packs API 로 검색 인덱스를 만든다.
- * - 3개 팩 배열(기본/치트키/구독)을 병합
- * - 잠긴 팩(미구독), tier2 잠금 이모티콘은 사용할 수 없으므로 제외
- */
-const fetchEmojiIndex = async (channelId: string): Promise<EmojiIndexItem[]> => {
-  const res = await fetch(`https://api.chzzk.naver.com/service/v1/channels/${channelId}/emoji-packs`, {
-    credentials: 'include',
-  });
-  if (!res.ok) throw new Error(`emoji-packs HTTP ${res.status}`);
-
-  const { content } = (await res.json()) as { content: EmojiPacksContent };
-  const packs = [...content.emojiPacks, ...content.cheatKeyEmojiPacks, ...content.subscriptionEmojiPacks];
-
-  return packs.flatMap(pack => {
-    if (pack.emojiPackLocked) return [];
-
-    const lockedTier2 = new Set((pack.emojiTier2Locked ? (pack.tier2Emojis ?? []) : []).map(e => e.emojiId));
-
-    return pack.emojis
-      .filter(e => !lockedTier2.has(e.emojiId))
-      .map(e => ({
-        emojiId: e.emojiId,
-        imageUrl: e.imageUrl,
-        packId: pack.emojiPackId,
-        packName: pack.emojiPackName,
-      }));
-  });
-};
 
 // 팝업(#emoji_area) 안에서 해당 이모티콘의 네이티브 버튼을 찾는다.
 // 우리 검색 UI 도 #emoji_area 안에 마운트되고 결과 img 의 alt 포맷이 동일하므로,
@@ -109,6 +52,7 @@ const insertEmoji = async ({ emojiId, packId }: EmojiIndexItem): Promise<void> =
 
 export default function ChatEmojiSearch() {
   const [index, setIndex] = useState<EmojiIndexItem[]>([]);
+  const [tags, setTags] = useState<EmojiTags>({});
   const [query, setQuery] = useState('');
   const [failed, setFailed] = useState(false);
   // 키보드(Tab/방향키)로 선택된 결과 인덱스. -1 = 선택 없음
@@ -128,20 +72,51 @@ export default function ChatEmojiSearch() {
       return;
     }
 
-    fetchEmojiIndex(channelId)
+    getEmojiIndex(channelId)
       .then(setIndex)
       .catch(() => setFailed(true));
   }, []);
 
-  // TODO: 태그 검색 - 현재는 치지직 API 에서 제공하는 emojiId, packName 으로만(휴먼리더블x) 검색 가능.
+  // 사용자 태그 로드 + 변경(태그 모달에서 편집) 실시간 반영,
+  // 태그 chip 클릭(태그 모달) → 검색어로 적용 (일회성 키, 수신 후 삭제)
+  useEffect(() => {
+    loadEmojiTags().then(setTags); // 최초 실행이면 기본 태그 시드
+
+    chrome.storage.local.get([CHAT_EMOJI_TAG_QUERY], res => {
+      if (res[CHAT_EMOJI_TAG_QUERY]) {
+        setQuery(res[CHAT_EMOJI_TAG_QUERY]);
+        chrome.storage.local.remove(CHAT_EMOJI_TAG_QUERY);
+        inputRef.current?.focus();
+      }
+    });
+
+    const onStorageChanged = (changes: { [key: string]: chrome.storage.StorageChange }) => {
+      if (CHAT_EMOJI_TAGS in changes) {
+        setTags(changes[CHAT_EMOJI_TAGS].newValue ?? {});
+      }
+      if (CHAT_EMOJI_TAG_QUERY in changes && changes[CHAT_EMOJI_TAG_QUERY].newValue) {
+        setQuery(changes[CHAT_EMOJI_TAG_QUERY].newValue);
+        chrome.storage.local.remove(CHAT_EMOJI_TAG_QUERY);
+        inputRef.current?.focus();
+      }
+    };
+    chrome.storage.onChanged.addListener(onStorageChanged);
+    return () => chrome.storage.onChanged.removeListener(onStorageChanged);
+  }, []);
+
   const results = useMemo(() => {
     const q = query.trim().toLowerCase();
     if (!q) return [];
 
     return index
-      .filter(e => e.emojiId.toLowerCase().includes(q) || e.packName.toLowerCase().includes(q))
+      .filter(
+        e =>
+          e.emojiId.toLowerCase().includes(q) ||
+          e.packName.toLowerCase().includes(q) ||
+          (tags[e.emojiId]?.some(tag => tag.toLowerCase().includes(q)) ?? false),
+      )
       .slice(0, MAX_RESULTS);
-  }, [query, index]);
+  }, [query, index, tags]);
 
   // 검색어가 바뀌면 선택 초기화
   useEffect(() => {
@@ -204,19 +179,48 @@ export default function ChatEmojiSearch() {
     }
   };
 
+  const openTagModal = (): void => {
+    chrome.storage.local.set({ [CHAT_EMOJI_TAG_MODAL]: true });
+  };
+
   return (
     <div>
       <strong className="czp-emoji-search-header">이모티콘 검색</strong>
-      <input
-        ref={inputRef}
-        className="czp-emoji-search-input"
-        type="text"
-        placeholder={failed ? '이모티콘 목록을 불러오지 못했어요' : '이모티콘 검색'}
-        disabled={failed}
-        value={query}
-        onChange={e => setQuery(e.target.value)}
-        onKeyDown={onKeyDown}
-      />
+      <div className="czp-emoji-search-input-wrap">
+        <input
+          ref={inputRef}
+          className="czp-emoji-search-input"
+          type="text"
+          placeholder={failed ? '이모티콘 목록을 불러오지 못했어요' : '이모티콘 검색'}
+          disabled={failed}
+          value={query}
+          onChange={e => setQuery(e.target.value)}
+          onKeyDown={onKeyDown}
+        />
+        <button
+          type="button"
+          className="czp-emoji-search-tag-btn"
+          title="이모티콘 태그"
+          onClick={openTagModal}
+          // 검색창 포커스를 뺏지 않게
+          onMouseDown={e => e.preventDefault()}
+        >
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            viewBox="0 0 24 24"
+            width="16"
+            height="16"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          >
+            <path d="M12.586 2.586A2 2 0 0 0 11.172 2H4a2 2 0 0 0-2 2v7.172a2 2 0 0 0 .586 1.414l8.704 8.704a2.426 2.426 0 0 0 3.42 0l6.58-6.58a2.426 2.426 0 0 0 0-3.42z" />
+            <circle cx="7.5" cy="7.5" r="0.5" fill="currentColor" />
+          </svg>
+        </button>
+      </div>
       {query.trim() !== '' && (
         <ul ref={gridRef} className="czp-emoji-search-results">
           {results.length === 0 ? (
@@ -227,7 +231,7 @@ export default function ChatEmojiSearch() {
                 <button
                   type="button"
                   className={`czp-emoji-search-item${i === selected ? ' czp-emoji-search-item--selected' : ''}`}
-                  title={`${e.emojiId} · ${e.packName}`}
+                  title={`${e.emojiId} · ${e.packName}${tags[e.emojiId]?.length ? ` · ${tags[e.emojiId].join(', ')}` : ''}`}
                   onClick={() => insertEmoji(e)}
                   // 버튼이 포커스를 뺏지 않게 → 검색창 포커스 유지, 클릭 후 Enter 재입력 방지
                   onMouseDown={e => e.preventDefault()}

--- a/src/components/ChatEmojiSearch/ChatEmojiSearch.tsx
+++ b/src/components/ChatEmojiSearch/ChatEmojiSearch.tsx
@@ -185,7 +185,7 @@ export default function ChatEmojiSearch() {
   };
 
   return (
-    <div className="czp-emoji-search">
+    <div className={CHAT_EMOJI_SEARCH_ROOT_CLASS}>
       <strong className="czp-emoji-search-header">이모티콘 검색</strong>
       <div className="czp-emoji-search-input-wrap">
         <input

--- a/src/components/modal/chatEmojiTagModal/ChatEmojiTagModal.css
+++ b/src/components/modal/chatEmojiTagModal/ChatEmojiTagModal.css
@@ -1,0 +1,150 @@
+.czp-emoji-tag-modal {
+  position: fixed;
+  left: 50%;
+  top: 50%;
+  z-index: 1000;
+  display: flex;
+  flex-direction: column;
+  width: 26rem;
+  max-height: 32rem;
+  padding: 1.5rem;
+  border-radius: 0.5rem;
+  transform: translate(-50%, -50%);
+  box-shadow:
+    0 0 30px 0 var(--color-shadow-layer03-02),
+    0 0 6px 0 var(--color-shadow-layer03-01);
+  background: var(--color-bg-layer-02);
+}
+
+.czp-emoji-tag-modal-close {
+  position: absolute;
+  right: 0.75rem;
+  top: 0.5rem;
+  border: none;
+  background: transparent;
+  color: var(--color-content-02);
+  font-size: 1.25rem;
+  cursor: pointer;
+}
+
+.czp-emoji-tag-heading {
+  margin: 0 0 0.75rem;
+  font-size: 1rem;
+}
+
+.czp-emoji-tag-all {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+  margin-bottom: 0.75rem;
+}
+
+.czp-emoji-tag-chip {
+  padding: 2px 8px;
+  border: 1px solid rgba(255, 255, 255, 0.15);
+  border-radius: 10px;
+  background: rgba(255, 255, 255, 0.06);
+  color: inherit;
+  font-size: 12px;
+  cursor: pointer;
+}
+
+.czp-emoji-tag-chip:hover {
+  border-color: #2cbf8a;
+  color: #2cbf8a;
+}
+
+.czp-emoji-tag-desc {
+  margin: 0 0 0.5rem;
+  color: rgba(160, 160, 160, 0.9);
+  font-size: 12px;
+}
+
+.czp-emoji-tag-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(36px, 1fr));
+  gap: 4px;
+  flex: 1;
+  min-height: 8rem;
+  margin: 0;
+  padding: 4px;
+  overflow-y: auto;
+  list-style: none;
+}
+
+.czp-emoji-tag-grid-item {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  padding: 2px;
+  border: 1px solid transparent;
+  border-radius: 6px;
+  background: transparent;
+  cursor: pointer;
+}
+
+.czp-emoji-tag-grid-item:hover {
+  background: rgba(255, 255, 255, 0.12);
+}
+
+.czp-emoji-tag-grid-item--tagged {
+  border-color: rgba(44, 191, 138, 0.5); /* 태그가 있는 이모티콘 표시 */
+}
+
+.czp-emoji-tag-grid-item--selected {
+  border-color: #2cbf8a;
+  background: rgba(44, 191, 138, 0.15);
+}
+
+.czp-emoji-tag-grid-item img {
+  width: 28px;
+  height: 28px;
+  object-fit: contain;
+}
+
+.czp-emoji-tag-editor {
+  display: flex;
+  gap: 10px;
+  align-items: flex-start;
+  margin-top: 0.75rem;
+  padding-top: 0.75rem;
+  border-top: 1px solid rgba(255, 255, 255, 0.1);
+}
+
+.czp-emoji-tag-editor > img {
+  width: 36px;
+  height: 36px;
+  object-fit: contain;
+}
+
+.czp-emoji-tag-editor-body {
+  flex: 1;
+}
+
+.czp-emoji-tag-editor-chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+  margin-bottom: 6px;
+}
+
+.czp-emoji-tag-editor-chips:empty {
+  display: none;
+}
+
+.czp-emoji-tag-editor-input {
+  box-sizing: border-box;
+  width: 100%;
+  padding: 5px 8px;
+  border: 1px solid rgba(255, 255, 255, 0.14);
+  border-radius: 6px;
+  background: rgba(255, 255, 255, 0.06);
+  color: inherit;
+  font-size: 13px;
+  outline: none;
+}
+
+.czp-emoji-tag-editor-input:focus {
+  border-color: #2cbf8a;
+}

--- a/src/components/modal/chatEmojiTagModal/ChatEmojiTagModal.css
+++ b/src/components/modal/chatEmojiTagModal/ChatEmojiTagModal.css
@@ -54,6 +54,43 @@
   color: #2cbf8a;
 }
 
+/* 상단 전체 태그 chip: 라벨(필터) + ×(일괄 삭제) 분리형 */
+.czp-emoji-tag-chip--split {
+  display: inline-flex;
+  align-items: center;
+  gap: 2px;
+  padding: 2px 4px 2px 8px;
+  cursor: default;
+}
+
+.czp-emoji-tag-chip--split:hover {
+  border-color: rgba(255, 255, 255, 0.15); /* 컨테이너는 hover 반응 없음 (내부 버튼이 각자 반응) */
+  color: inherit;
+}
+
+.czp-emoji-tag-chip-label,
+.czp-emoji-tag-chip-remove {
+  padding: 0;
+  border: none;
+  background: transparent;
+  color: inherit;
+  font-size: inherit;
+  cursor: pointer;
+}
+
+.czp-emoji-tag-chip-label:hover {
+  color: #2cbf8a;
+}
+
+.czp-emoji-tag-chip-remove {
+  padding: 0 3px;
+  color: rgba(160, 160, 160, 0.9);
+}
+
+.czp-emoji-tag-chip-remove:hover {
+  color: #ff6b6b;
+}
+
 .czp-emoji-tag-desc {
   margin: 0 0 0.5rem;
   color: rgba(160, 160, 160, 0.9);

--- a/src/components/modal/chatEmojiTagModal/ChatEmojiTagModal.css
+++ b/src/components/modal/chatEmojiTagModal/ChatEmojiTagModal.css
@@ -41,9 +41,9 @@
 
 .czp-emoji-tag-chip {
   padding: 2px 8px;
-  border: 1px solid rgba(255, 255, 255, 0.15);
+  border: 1px solid rgba(var(--color-border-01-rgb), 0.2);
   border-radius: 10px;
-  background: rgba(255, 255, 255, 0.06);
+  background: var(--color-bg-03, rgba(255, 255, 255, 0.06));
   color: inherit;
   font-size: 12px;
   cursor: pointer;
@@ -64,7 +64,7 @@
 }
 
 .czp-emoji-tag-chip--split:hover {
-  border-color: rgba(255, 255, 255, 0.15); /* 컨테이너는 hover 반응 없음 (내부 버튼이 각자 반응) */
+  border-color: rgba(var(--color-border-01-rgb), 0.2); /* 컨테이너는 hover 반응 없음 (내부 버튼이 각자 반응) */
   color: inherit;
 }
 
@@ -84,7 +84,7 @@
 
 .czp-emoji-tag-chip-remove {
   padding: 0 3px;
-  color: rgba(160, 160, 160, 0.9);
+  color: var(--color-content-02);
 }
 
 .czp-emoji-tag-chip-remove:hover {
@@ -93,7 +93,7 @@
 
 .czp-emoji-tag-desc {
   margin: 0 0 0.5rem;
-  color: rgba(160, 160, 160, 0.9);
+  color: var(--color-content-02);
   font-size: 12px;
 }
 
@@ -122,7 +122,7 @@
 }
 
 .czp-emoji-tag-grid-item:hover {
-  background: rgba(255, 255, 255, 0.12);
+  background: rgba(var(--color-border-01-rgb), 0.12);
 }
 
 .czp-emoji-tag-grid-item--tagged {
@@ -146,7 +146,7 @@
   align-items: flex-start;
   margin-top: 0.75rem;
   padding-top: 0.75rem;
-  border-top: 1px solid rgba(255, 255, 255, 0.1);
+  border-top: 1px solid rgba(var(--color-border-01-rgb), 0.1);
 }
 
 .czp-emoji-tag-editor > img {
@@ -174,9 +174,9 @@
   box-sizing: border-box;
   width: 100%;
   padding: 5px 8px;
-  border: 1px solid rgba(255, 255, 255, 0.14);
+  border: 1px solid rgba(var(--color-border-01-rgb), 0.2);
   border-radius: 6px;
-  background: rgba(255, 255, 255, 0.06);
+  background: var(--color-bg-03, rgba(255, 255, 255, 0.06));
   color: inherit;
   font-size: 13px;
   outline: none;

--- a/src/components/modal/chatEmojiTagModal/ChatEmojiTagModal.tsx
+++ b/src/components/modal/chatEmojiTagModal/ChatEmojiTagModal.tsx
@@ -1,0 +1,171 @@
+import { useEffect, useMemo, useState } from 'react';
+import { CHAT_EMOJI_TAG_MODAL, CHAT_EMOJI_TAG_QUERY, CHAT_EMOJI_TAGS } from '../../../constants/storage';
+import { getChannelIDByUrl } from '../../../utils/channel';
+import { getEmojiIndex, loadEmojiTags, type EmojiIndexItem, type EmojiTags } from '../../../utils/emoji';
+import './ChatEmojiTagModal.css';
+
+const saveTags = (tags: EmojiTags): void => {
+  chrome.storage.local.set({ [CHAT_EMOJI_TAGS]: tags });
+};
+
+const TagEditor = () => {
+  const [index, setIndex] = useState<EmojiIndexItem[]>([]);
+  const [tags, setTags] = useState<EmojiTags>({});
+  const [selectedEmojiId, setSelectedEmojiId] = useState<string | null>(null);
+  const [tagInput, setTagInput] = useState('');
+
+  // 인덱스(현재 채널) + 저장된 태그 로드
+  useEffect(() => {
+    const channelId = getChannelIDByUrl(document.URL);
+    if (channelId) {
+      getEmojiIndex(channelId)
+        .then(setIndex)
+        .catch(() => setIndex([]));
+    }
+
+    loadEmojiTags().then(setTags); // 최초 실행이면 기본 태그 시드
+  }, []);
+
+  const selectedEmoji = useMemo(() => index.find(e => e.emojiId === selectedEmojiId) ?? null, [index, selectedEmojiId]);
+
+  // 저장된 전체 태그 목록 (중복 제거, 가나다순)
+  const allTags = useMemo(() => [...new Set(Object.values(tags).flat())].sort(), [tags]);
+
+  const updateTags = (next: EmojiTags): void => {
+    setTags(next);
+    saveTags(next);
+  };
+
+  const addTag = (): void => {
+    const tag = tagInput.trim();
+    if (!tag || !selectedEmojiId) return;
+
+    const current = tags[selectedEmojiId] ?? [];
+    if (!current.includes(tag)) {
+      updateTags({ ...tags, [selectedEmojiId]: [...current, tag] });
+    }
+    setTagInput('');
+  };
+
+  const removeTag = (emojiId: string, tag: string): void => {
+    const remain = (tags[emojiId] ?? []).filter(t => t !== tag);
+    const next = { ...tags };
+
+    if (remain.length === 0) {
+      delete next[emojiId]; // 빈 배열은 키째로 정리
+    } else {
+      next[emojiId] = remain;
+    }
+    updateTags(next);
+  };
+
+  // 태그 chip 클릭 → 검색창에 검색어로 전달하고 모달 닫기
+  const applyTagFilter = (tag: string): void => {
+    chrome.storage.local.set({
+      [CHAT_EMOJI_TAG_QUERY]: tag,
+      [CHAT_EMOJI_TAG_MODAL]: false,
+    });
+  };
+
+  return (
+    <>
+      <h2 className="czp-emoji-tag-heading">이모티콘 태그</h2>
+
+      {allTags.length > 0 && (
+        <div className="czp-emoji-tag-all">
+          {allTags.map(tag => (
+            <button key={tag} type="button" className="czp-emoji-tag-chip" onClick={() => applyTagFilter(tag)}>
+              #{tag}
+            </button>
+          ))}
+        </div>
+      )}
+
+      <p className="czp-emoji-tag-desc">이모티콘을 선택하고 태그를 추가하세요. 태그는 검색에 사용됩니다.</p>
+
+      <ul className="czp-emoji-tag-grid">
+        {index.map(e => (
+          <li key={e.emojiId}>
+            <button
+              type="button"
+              className={`czp-emoji-tag-grid-item${e.emojiId === selectedEmojiId ? ' czp-emoji-tag-grid-item--selected' : ''}${tags[e.emojiId]?.length ? ' czp-emoji-tag-grid-item--tagged' : ''}`}
+              title={`${e.emojiId} · ${e.packName}`}
+              onClick={() => setSelectedEmojiId(e.emojiId)}
+            >
+              <img src={e.imageUrl} alt={e.emojiId} loading="lazy" />
+            </button>
+          </li>
+        ))}
+      </ul>
+
+      {selectedEmoji && (
+        <div className="czp-emoji-tag-editor">
+          <img src={selectedEmoji.imageUrl} alt={selectedEmoji.emojiId} />
+          <div className="czp-emoji-tag-editor-body">
+            <div className="czp-emoji-tag-editor-chips">
+              {(tags[selectedEmoji.emojiId] ?? []).map(tag => (
+                <button
+                  key={tag}
+                  type="button"
+                  className="czp-emoji-tag-chip"
+                  title="클릭해서 삭제"
+                  onClick={() => removeTag(selectedEmoji.emojiId, tag)}
+                >
+                  #{tag} ×
+                </button>
+              ))}
+            </div>
+            <input
+              type="text"
+              className="czp-emoji-tag-editor-input"
+              placeholder="태그 입력 후 Enter"
+              value={tagInput}
+              onChange={e => setTagInput(e.target.value)}
+              onKeyDown={e => {
+                e.stopPropagation();
+                if (e.key === 'Enter') addTag();
+              }}
+            />
+          </div>
+        </div>
+      )}
+    </>
+  );
+};
+
+// MESSAGE_STORAGE_MODAL 패턴: storage 플래그로 열림/닫힘 제어 (전역 마운트)
+export default function ChatEmojiTagModal() {
+  const [open, setOpen] = useState(false);
+
+  useEffect(() => {
+    chrome.storage.local.get([CHAT_EMOJI_TAG_MODAL], res => {
+      setOpen(!!res[CHAT_EMOJI_TAG_MODAL]);
+    });
+
+    const onStorageChanged = (changes: { [key: string]: chrome.storage.StorageChange }) => {
+      if (CHAT_EMOJI_TAG_MODAL in changes) {
+        setOpen(!!changes[CHAT_EMOJI_TAG_MODAL].newValue);
+      }
+    };
+    chrome.storage.onChanged.addListener(onStorageChanged);
+    return () => chrome.storage.onChanged.removeListener(onStorageChanged);
+  }, []);
+
+  const close = (): void => {
+    chrome.storage.local.set({ [CHAT_EMOJI_TAG_MODAL]: false });
+  };
+
+  // createReactElement 시그니처가 () => JSX.Element 라서 null 대신 빈 프래그먼트 (MessageStorageModal 패턴)
+  return (
+    <>
+      {open && (
+        <div className="czp-emoji-tag-modal">
+          <button type="button" className="czp-emoji-tag-modal-close" onClick={close}>
+            ×
+          </button>
+          <TagEditor />
+        </div>
+      )}
+    </>
+  );
+}

--- a/src/components/modal/chatEmojiTagModal/ChatEmojiTagModal.tsx
+++ b/src/components/modal/chatEmojiTagModal/ChatEmojiTagModal.tsx
@@ -67,6 +67,18 @@ const TagEditor = () => {
     });
   };
 
+  // 해당 태그를 모든 이모티콘에서 일괄 삭제
+  const removeTagEverywhere = (tag: string): void => {
+    if (!confirm(`'#${tag}' 태그를 모든 이모티콘에서 삭제할까요?`)) return;
+
+    const next: EmojiTags = {};
+    for (const [emojiId, emojiTags] of Object.entries(tags)) {
+      const remain = emojiTags.filter(t => t !== tag);
+      if (remain.length > 0) next[emojiId] = remain;
+    }
+    updateTags(next);
+  };
+
   return (
     <>
       <h2 className="czp-emoji-tag-heading">이모티콘 태그</h2>
@@ -74,9 +86,24 @@ const TagEditor = () => {
       {allTags.length > 0 && (
         <div className="czp-emoji-tag-all">
           {allTags.map(tag => (
-            <button key={tag} type="button" className="czp-emoji-tag-chip" onClick={() => applyTagFilter(tag)}>
-              #{tag}
-            </button>
+            <span key={tag} className="czp-emoji-tag-chip czp-emoji-tag-chip--split">
+              <button
+                type="button"
+                className="czp-emoji-tag-chip-label"
+                title="이 태그로 검색"
+                onClick={() => applyTagFilter(tag)}
+              >
+                #{tag}
+              </button>
+              <button
+                type="button"
+                className="czp-emoji-tag-chip-remove"
+                title="이 태그를 모든 이모티콘에서 삭제"
+                onClick={() => removeTagEverywhere(tag)}
+              >
+                ×
+              </button>
+            </span>
           ))}
         </div>
       )}
@@ -123,6 +150,9 @@ const TagEditor = () => {
               onChange={e => setTagInput(e.target.value)}
               onKeyDown={e => {
                 e.stopPropagation();
+                // 한글 IME 조합 중 Enter 는 keydown 이 2회(조합 확정 + 실제) 발화 → 조합 확정분은 무시
+                // (미처리 시 마지막 글자가 별도 태그로 한 번 더 추가됨)
+                if (e.nativeEvent.isComposing) return;
                 if (e.key === 'Enter') addTag();
               }}
             />

--- a/src/constants/class.ts
+++ b/src/constants/class.ts
@@ -85,6 +85,9 @@ export const CHATTING_AREA = byClass('live_chatting_area__');
 export const CHATTING_BADGE = '._wrapper_o04z9_23';
 // 채팅 입력창 (버퍼/지연 시간을 placeholder 로 표시). css-module + webpack 폴백 union.
 export const CHAT_INPUT = '._input_1xxwu_59._default_1xxwu_77, [class*="live_chatting_input_input__"]';
+// 채팅 입력창의 contenteditable 요소. CHAT_INPUT 은 _default_ 클래스를 요구해 내용이 있으면 매칭 실패하므로,
+// 포커스 용도로는 해시에 의존하지 않는 이 셀렉터를 사용한다.
+export const CHAT_INPUT_EDITABLE = '#aside-chatting pre[contenteditable="true"]';
 export const CHAT_USER_AREA = '._area_1qgfi_49';
 
 // 동영상 Card UI

--- a/src/constants/class.ts
+++ b/src/constants/class.ts
@@ -51,6 +51,13 @@ export const SUBSCRIBE_CHAT = byClass('live_chatting_list_subscription__');
 export const CHEEZE_RANKING_CHAT = '._container_4gn4x_2';
 export const CHAT_BUTTON = byClass('live_chatting_message_nickname__');
 
+// 채팅 이모티콘
+export const CHAT_EMOJI_AREA = '#emoji_area';
+// 이모티콘 팩 탭의 id prefix (예: emoji_pack_id_dp_1)
+export const EMOJI_PACK_TAB_ID_PREFIX = 'emoji_pack_id_';
+// 이모티콘 검색 UI 루트 클래스 (#emoji_area 안에 마운트되므로, 네이티브 버튼 탐색 시 이 하위는 제외)
+export const CHAT_EMOJI_SEARCH_ROOT_CLASS = 'czp-chat-emoji-search';
+
 // UI 정보
 export const LIVE_CONTROL_MENU = '._control_1nl77_246';
 export const VIDEO_BUTTONS = '.pzp-pc__bottom-buttons-right';
@@ -63,6 +70,8 @@ export const USER_POPUP_NAME =
 
 // VOD(다시보기) 페이지의 우측 채팅/정보 패널 (#aside-chatting 의 video 버전)
 export const VOD_ASIDE = '#vod-aside';
+// Aside 패널에서 팝업된 영역의 컨텐츠 컨테이너
+export const ASIDE_POPUP_CONTENTS = '#popup_contents';
 
 // 채팅
 export const CHATTING_TOOLS = '#aside-chatting';
@@ -76,7 +85,7 @@ export const CHATTING_AREA = byClass('live_chatting_area__');
 export const CHATTING_BADGE = '._wrapper_o04z9_23';
 // 채팅 입력창 (버퍼/지연 시간을 placeholder 로 표시). css-module + webpack 폴백 union.
 export const CHAT_INPUT = '._input_1xxwu_59._default_1xxwu_77, [class*="live_chatting_input_input__"]';
-export const CHAT_USER_AREA = '.area_1qgfi_49';
+export const CHAT_USER_AREA = '._area_1qgfi_49';
 
 // 동영상 Card UI
 export const VIDEO_CARD_LIST = '.component_list__DNd2B'; // 라이브 페이지의 비디오 ul

--- a/src/constants/storage.ts
+++ b/src/constants/storage.ts
@@ -67,6 +67,9 @@ export const FAVORITE_GROUPS = 'czp-favorite-groups';
 export const CHAT_STORAGE = 'czp-chat-storage';
 export const CHAT_STORAGE_ENABLE = 'czp-chat-storage-enable';
 
+// 채팅 이모티콘
+export const CHAT_EMOJI_SEARCH_ENABLE = 'czp-chat-emoji-search-enable';
+
 // 생방송 새로고침
 export const ONLIVE_REFRESH = 'czp-live-refresh';
 

--- a/src/constants/storage.ts
+++ b/src/constants/storage.ts
@@ -69,6 +69,12 @@ export const CHAT_STORAGE_ENABLE = 'czp-chat-storage-enable';
 
 // 채팅 이모티콘
 export const CHAT_EMOJI_SEARCH_ENABLE = 'czp-chat-emoji-search-enable';
+// 이모티콘별 사용자 태그: Record<emojiId, string[]>
+export const CHAT_EMOJI_TAGS = 'czp-chat-emoji-tags';
+// 태그 편집 모달 열림 플래그 (MESSAGE_STORAGE_MODAL 패턴)
+export const CHAT_EMOJI_TAG_MODAL = 'czp-chat-emoji-tag-modal';
+// 태그 chip 클릭 → 검색창에 적용할 태그 검색어 전달용 (일회성, 수신 후 삭제)
+export const CHAT_EMOJI_TAG_QUERY = 'czp-chat-emoji-tag-query';
 
 // 생방송 새로고침
 export const ONLIVE_REFRESH = 'czp-live-refresh';

--- a/src/content.tsx
+++ b/src/content.tsx
@@ -13,6 +13,7 @@ import { initTabViewerCount } from './feature/tabViewerCount';
 import { initPowerCollect } from './feature/powerCollect';
 import { initLayoutCustom } from './feature/layoutCustom';
 import { initChatTimestamp } from './feature/chatTimestamp';
+import { initChatEmojiSearch } from './feature/chatEmojiSearch';
 
 /**
  * MAIN world(페이지 컨텍스트)에서 동작하는 inject.js 를 주입한다.
@@ -149,6 +150,7 @@ function installChildStyleObserver($layout: HTMLElement) {
   initPowerCollect();
   initLayoutCustom();
   initChatTimestamp();
+  initChatEmojiSearch();
 
   const $layout = await waitingElement(`#${LAYOUT_WRAP}`, 30000);
   if (!$layout) return;

--- a/src/feature/chatEmojiSearch.ts
+++ b/src/feature/chatEmojiSearch.ts
@@ -12,18 +12,76 @@
 import { isLivePage } from '../utils/page';
 import {
   CHAT_CONTAINER,
+  CHAT_INPUT_EDITABLE,
   CHAT_USER_AREA,
   CHAT_EMOJI_AREA,
   ASIDE_POPUP_CONTENTS,
   CHAT_EMOJI_SEARCH_ROOT_CLASS,
 } from '../constants/class';
 import { CHAT_EMOJI_SEARCH_ENABLE } from '../constants/storage';
-import { createReactElement } from '../utils/dom';
+import { createReactElement, dispatchMouseClickSequence } from '../utils/dom';
 import ChatEmojiSearch from '../components/ChatEmojiSearch/ChatEmojiSearch';
 
 const MARKER_CLASS = CHAT_EMOJI_SEARCH_ROOT_CLASS;
 
 let enabled = false;
+
+// 이모티콘 팝업을 닫는다 — 팝업을 연 토글 버튼(aria-expanded)을 다시 눌러 치지직 자체 닫기 경로를 재사용.
+// 토글 버튼은 해시 클래스뿐이라, 네이버 a11y 클래스(.blind)의 텍스트 "이모티콘" 으로 특정한다.
+const closeEmojiPopup = (): void => {
+  const $toggles = document.querySelectorAll<HTMLButtonElement>(`${CHAT_CONTAINER} button[aria-expanded="true"]`);
+  const $emojiToggle = [...$toggles].find($btn => $btn.querySelector('.blind')?.textContent === '이모티콘');
+
+  $emojiToggle?.click();
+};
+
+// contenteditable 요소의 캐럿을 내용 맨 끝으로 이동시킨다. (포커스 직후 기본 위치는 맨 앞)
+const moveCaretToEnd = ($el: HTMLElement): void => {
+  const range = document.createRange();
+  range.selectNodeContents($el);
+  range.collapse(false); // false = 끝으로 접기
+
+  const selection = window.getSelection();
+  selection?.removeAllRanges();
+  selection?.addRange(range);
+};
+
+// 채팅 입력창(contenteditable pre)에 포커스를 준다.
+// CHAT_INPUT(_default_ 클래스 요구)은 입력창에 내용이 있으면 매칭되지 않으므로 CHAT_INPUT_EDITABLE 을 사용.
+//
+// 팝업이 닫힐 때 치지직이 입력 영역을 리렌더하면서 포커스했던 노드가 교체될 수 있으므로,
+// 리렌더가 가라앉을 때까지 재조회 + 재시도한다 (50ms × 10회).
+const focusChatInput = async (): Promise<void> => {
+  for (let i = 0; i < 10; i++) {
+    const $input = document.querySelector<HTMLElement>(CHAT_INPUT_EDITABLE);
+
+    if ($input) {
+      $input.focus();
+      if (document.activeElement === $input) {
+        moveCaretToEnd($input);
+        return;
+      }
+
+      // focus() 가 무시되는 상태면 실제 클릭과 동일한 시퀀스로 치지직 포커스 로직을 태운다
+      dispatchMouseClickSequence($input, true);
+      if (document.activeElement === $input) {
+        moveCaretToEnd($input);
+        return;
+      }
+    }
+
+    await new Promise(resolve => setTimeout(resolve, 50));
+  }
+};
+
+// 팝업이 열려 있을 때 Esc 로 닫기 (포커스 위치 무관).
+// capture 단계라 다른 핸들러의 stopPropagation 에 막히지 않는다.
+// 같은 함수 참조로 add/remove 하므로 중복 등록되지 않는다.
+const onDocumentKeyDown = (e: KeyboardEvent): void => {
+  if (e.key !== 'Escape') return;
+  if (!document.querySelector(CHAT_EMOJI_AREA)) return; // 팝업 닫혀 있으면 무시
+  closeEmojiPopup();
+};
 
 // === 채팅 이모티콘 팝업 컨테이너 ===
 // CHAT_EMOJI_AREA 와 ASIDE_POPUP_CONTENTS 가 존재하면, 이모티콘 컨테이너가 존재하는 것으로 간주한다.
@@ -52,6 +110,7 @@ const findChatEmojiPopUpContainer = (): ChatEmojiPopUpContainer | null => {
 // === 옵저버 ===
 let rootObserver: MutationObserver | null = null;
 let $observedTarget: Element | null = null;
+let popupWasOpen = false;
 
 // 영속 앵커에 상주 — 팝업의 등장 자체를 감지
 const startObserver = () => {
@@ -80,14 +139,25 @@ const startObserver = () => {
         createReactElement($root, ChatEmojiSearch);
       }
     }
+
+    // 팝업 열림 → 닫힘 전이 감지 시 채팅 입력창으로 포커스 복귀
+    // (열림 시 검색창 포커스는 컴포넌트 마운트 effect 가 담당)
+    const isOpen = !!document.querySelector(CHAT_EMOJI_AREA);
+    if (popupWasOpen && !isOpen) {
+      focusChatInput();
+    }
+    popupWasOpen = isOpen;
   });
   rootObserver.observe($chatUserArea, { childList: true, subtree: true });
+  document.addEventListener('keydown', onDocumentKeyDown, true);
 };
 
 const stopObserver = (): void => {
   rootObserver?.disconnect();
   rootObserver = null;
   $observedTarget = null;
+  popupWasOpen = false;
+  document.removeEventListener('keydown', onDocumentKeyDown, true);
   document.querySelectorAll(`.${MARKER_CLASS}`).forEach(el => el.remove());
 };
 // === 옵저버 END ===

--- a/src/feature/chatEmojiSearch.ts
+++ b/src/feature/chatEmojiSearch.ts
@@ -152,7 +152,6 @@ const startObserver = () => {
 
         const $root = document.createElement('div');
         $root.className = MARKER_CLASS;
-        
 
         $area.prepend($root);
         createReactElement($root, ChatEmojiSearch);

--- a/src/feature/chatEmojiSearch.ts
+++ b/src/feature/chatEmojiSearch.ts
@@ -18,7 +18,7 @@ import {
   ASIDE_POPUP_CONTENTS,
   CHAT_EMOJI_SEARCH_ROOT_CLASS,
 } from '../constants/class';
-import { CHAT_EMOJI_SEARCH_ENABLE } from '../constants/storage';
+import { CHAT_EMOJI_SEARCH_ENABLE, CHAT_EMOJI_TAG_MODAL } from '../constants/storage';
 import { createReactElement, dispatchMouseClickSequence } from '../utils/dom';
 import ChatEmojiSearch from '../components/ChatEmojiSearch/ChatEmojiSearch';
 
@@ -74,13 +74,29 @@ const focusChatInput = async (): Promise<void> => {
   }
 };
 
-// 팝업이 열려 있을 때 Esc 로 닫기 (포커스 위치 무관).
-// capture 단계라 다른 핸들러의 stopPropagation 에 막히지 않는다.
-// 같은 함수 참조로 add/remove 하므로 중복 등록되지 않는다.
+// Esc 우선순위 체인 (포커스 위치 무관):
+// 1) 태그 모달이 열려 있으면 모달만 닫는다 (이모티콘 팝업은 유지)
+// 2) 이모티콘 팝업이 열려 있으면 팝업을 닫는다
+// 처리한 경우 이벤트를 소비해 치지직 자체 Esc 핸들러(전체화면 해제 등)까지 내려가지 않게 한다.
+// capture 단계라 다른 핸들러의 stopPropagation 에 막히지 않고, 같은 함수 참조로 add/remove 하므로 중복 등록되지 않는다.
 const onDocumentKeyDown = (e: KeyboardEvent): void => {
   if (e.key !== 'Escape') return;
-  if (!document.querySelector(CHAT_EMOJI_AREA)) return; // 팝업 닫혀 있으면 무시
-  closeEmojiPopup();
+
+  const consume = () => {
+    e.preventDefault();
+    e.stopPropagation();
+  };
+
+  if (document.querySelector('.czp-emoji-tag-modal')) {
+    consume();
+    chrome.storage.local.set({ [CHAT_EMOJI_TAG_MODAL]: false });
+    return;
+  }
+
+  if (document.querySelector(CHAT_EMOJI_AREA)) {
+    consume();
+    closeEmojiPopup();
+  }
 };
 
 // === 채팅 이모티콘 팝업 컨테이너 ===

--- a/src/feature/chatEmojiSearch.ts
+++ b/src/feature/chatEmojiSearch.ts
@@ -148,8 +148,11 @@ const startObserver = () => {
       const $area = $container.$area;
 
       if (!$area.querySelector(`.${MARKER_CLASS}`)) {
+        $container.$container.classList.add('czp-emoji-search-popup-expanded');
+
         const $root = document.createElement('div');
         $root.className = MARKER_CLASS;
+        
 
         $area.prepend($root);
         createReactElement($root, ChatEmojiSearch);

--- a/src/feature/chatEmojiSearch.ts
+++ b/src/feature/chatEmojiSearch.ts
@@ -1,0 +1,122 @@
+/**
+ * 채팅 이모티콘 검색.
+ *
+ * 이모티콘 팝업(#emoji_area)이 열리면 상단에 검색 UI 를 주입한다.
+ * 치지직 React 가 소유한 노드는 읽기만 하고, UI 는 우리가 만든 루트 div 안에서만 렌더링한다.
+ * 이모티콘 데이터는 emoji-packs API 로 인덱싱하고, 선택 시 네이티브 이모티콘 버튼 클릭을 재사용해 삽입한다.
+ * (다른 팩의 이모티콘은 팩 탭을 mousedown 디스패치로 전환한 뒤 클릭)
+ *
+ * 팝업은 열고 닫힐 때마다 DOM 에서 생성/제거되므로, 영속 앵커(채팅 하단 영역)에
+ * MutationObserver 를 상주시켜 팝업 등장을 감지하고 매번 재주입한다(idempotent).
+ */
+import { isLivePage } from '../utils/page';
+import {
+  CHAT_CONTAINER,
+  CHAT_USER_AREA,
+  CHAT_EMOJI_AREA,
+  ASIDE_POPUP_CONTENTS,
+  CHAT_EMOJI_SEARCH_ROOT_CLASS,
+} from '../constants/class';
+import { CHAT_EMOJI_SEARCH_ENABLE } from '../constants/storage';
+import { createReactElement } from '../utils/dom';
+import ChatEmojiSearch from '../components/ChatEmojiSearch/ChatEmojiSearch';
+
+const MARKER_CLASS = CHAT_EMOJI_SEARCH_ROOT_CLASS;
+
+let enabled = false;
+
+// === 채팅 이모티콘 팝업 컨테이너 ===
+// CHAT_EMOJI_AREA 와 ASIDE_POPUP_CONTENTS 가 존재하면, 이모티콘 컨테이너가 존재하는 것으로 간주한다.
+type ChatEmojiPopUpContainer = {
+  $container: HTMLElement;
+  $contents: HTMLElement;
+  $area: HTMLElement;
+};
+
+const findChatEmojiPopUpContainer = (): ChatEmojiPopUpContainer | null => {
+  if (!enabled || !isLivePage()) return null;
+
+  const $area = document.querySelector<HTMLElement>(CHAT_EMOJI_AREA);
+  if (!$area) return null;
+
+  const $contents = $area.closest<HTMLElement>(ASIDE_POPUP_CONTENTS);
+  if (!$contents) return null;
+
+  const $container = $contents.closest<HTMLElement>('[role="alertdialog"][aria-modal="true"]');
+  if (!$container) return null;
+
+  return { $container, $contents, $area };
+};
+// === 채팅 이모티콘 팝업 컨테이너 END ===
+
+// === 옵저버 ===
+let rootObserver: MutationObserver | null = null;
+let $observedTarget: Element | null = null;
+
+// 영속 앵커에 상주 — 팝업의 등장 자체를 감지
+const startObserver = () => {
+  const $aside = document.querySelector(CHAT_CONTAINER);
+  if (!$aside) return;
+
+  const $chatUserArea = $aside.querySelector(CHAT_USER_AREA);
+  if (!$chatUserArea) return;
+
+  // 살아있는 옵저버가 있으면 유지, 죽었으면(관찰 대상이 DOM 재구성으로 제거) 정리 후 재부착
+  if (rootObserver && $observedTarget && document.contains($observedTarget)) return;
+  stopObserver();
+
+  $observedTarget = $chatUserArea;
+  rootObserver = new MutationObserver(() => {
+    const $container = findChatEmojiPopUpContainer();
+
+    if ($container) {
+      const $area = $container.$area;
+
+      if (!$area.querySelector(`.${MARKER_CLASS}`)) {
+        const $root = document.createElement('div');
+        $root.className = MARKER_CLASS;
+
+        $area.prepend($root);
+        createReactElement($root, ChatEmojiSearch);
+      }
+    }
+  });
+  rootObserver.observe($chatUserArea, { childList: true, subtree: true });
+};
+
+const stopObserver = (): void => {
+  rootObserver?.disconnect();
+  rootObserver = null;
+  $observedTarget = null;
+  document.querySelectorAll(`.${MARKER_CLASS}`).forEach(el => el.remove());
+};
+// === 옵저버 END ===
+
+// === exported ===
+// 라이브 페이지 진입/재구성 시 호출 (채팅 컨테이너가 새로 생기면 재관찰).
+export const chatEmojiSearchSetting = (): void => {
+  if (enabled) startObserver();
+};
+
+// 채팅 이모티콘 검색 기능 초기화
+export const initChatEmojiSearch = (): void => {
+  // 초기 활성화 여부 확인
+  chrome.storage.local.get(CHAT_EMOJI_SEARCH_ENABLE, res => {
+    enabled = res[CHAT_EMOJI_SEARCH_ENABLE] ?? false;
+    if (enabled) startObserver();
+  });
+
+  // 이모티콘 검색 피쳐 활성화/비활성화 대응
+  chrome.storage.onChanged.addListener(changes => {
+    const change = changes[CHAT_EMOJI_SEARCH_ENABLE];
+    if (!change) return;
+
+    enabled = change.newValue ?? false;
+    if (enabled) {
+      startObserver();
+    } else {
+      stopObserver();
+    }
+  });
+};
+// === exported ===

--- a/src/page/global.ts
+++ b/src/page/global.ts
@@ -2,6 +2,7 @@ import { previewSetting } from '../feature/preview';
 import { chatSetting } from '../feature/chat';
 import { favoriteSetting } from '../feature/favorite';
 import MessageStorageModal from '../components/modal/messageStorageModal/MessageStorageModal';
+import ChatEmojiTagModal from '../components/modal/chatEmojiTagModal/ChatEmojiTagModal';
 
 import { log, logWarning } from '../utils/log';
 import { createReactElement } from '../utils/dom';
@@ -23,6 +24,10 @@ export const editGlobalPage = () => {
     const $storageModalRoot = document.createElement('div');
     $global.appendChild($storageModalRoot);
     createReactElement($storageModalRoot, MessageStorageModal); // 채팅 저장소
+
+    const $emojiTagModalRoot = document.createElement('div');
+    $global.appendChild($emojiTagModalRoot);
+    createReactElement($emojiTagModalRoot, ChatEmojiTagModal); // 이모티콘 태그
 
     const $settingModalRoot = document.createElement('div');
     $global.appendChild($settingModalRoot);

--- a/src/page/live.ts
+++ b/src/page/live.ts
@@ -31,6 +31,7 @@ import MessageStorageButton from '../components/button/MessageStorageButton/Mess
 import { traceOpenLive } from '../utils/trace';
 import { bufferDisplaySetting } from '../feature/bufferDisplay';
 import { chatTimestampSetting } from '../feature/chatTimestamp';
+import { chatEmojiSearchSetting } from '../feature/chatEmojiSearch';
 import PipButton from '../components/button/PipButton/PipButton';
 import ScreenGuardButton from '../components/button/ScreenGuardButton/ScreenGuardButton';
 import FavoriteButton from '../components/button/FavoriteButton/FavoriteButton';
@@ -72,6 +73,7 @@ export const editLivePage = async () => {
   bufferDisplaySetting();
   // 채팅 타임스탬프 (채팅 재구성 시 재관찰)
   chatTimestampSetting();
+  chatEmojiSearchSetting();
 
   const $chatToolsList = await waitingElement(CHATTING_TOOLS);
   if (!$chatToolsList) return;

--- a/src/utils/dom.ts
+++ b/src/utils/dom.ts
@@ -60,3 +60,15 @@ export const isTypingTarget = (target: EventTarget | null): boolean => {
   const tag = target.tagName;
   return tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT';
 };
+
+/**
+ * 실제 마우스 조작과 동일한 mousedown → mouseup(→ click) 시퀀스를 디스패치한다.
+ * 치지직 UI 중 일부(이모티콘 팩 탭, 채팅 입력창 포커스 등)는 click 이 아니라
+ * mousedown/mouseup 에 핸들러가 걸려 있어 el.click() 만으로는 동작하지 않는다.
+ */
+export const dispatchMouseClickSequence = ($el: HTMLElement, withClick: boolean = false): void => {
+  const base = { bubbles: true, cancelable: true, view: window, button: 0 };
+  $el.dispatchEvent(new MouseEvent('mousedown', { ...base, buttons: 1 }));
+  $el.dispatchEvent(new MouseEvent('mouseup', { ...base, buttons: 0 }));
+  if (withClick) $el.dispatchEvent(new MouseEvent('click', { ...base, buttons: 0 }));
+};

--- a/src/utils/dom.ts
+++ b/src/utils/dom.ts
@@ -62,7 +62,8 @@ export const isTypingTarget = (target: EventTarget | null): boolean => {
 };
 
 /**
- * 실제 마우스 조작과 동일한 mousedown → mouseup(→ click) 시퀀스를 디스패치한다.
+ * 실제 마우스 조작과 동일한 mousedown → mouseup 시퀀스를 디스패치한다.
+ * (withClick=true 를 넘기면 click 이벤트까지 함께 디스패치)
  * 치지직 UI 중 일부(이모티콘 팩 탭, 채팅 입력창 포커스 등)는 click 이 아니라
  * mousedown/mouseup 에 핸들러가 걸려 있어 el.click() 만으로는 동작하지 않는다.
  */

--- a/src/utils/emoji.ts
+++ b/src/utils/emoji.ts
@@ -100,6 +100,8 @@ const fetchEmojiIndex = async (channelId: string): Promise<EmojiIndexItem[]> => 
 };
 
 // 채널별 인덱스 캐시 — 검색 UI 와 태그 모달이 각자 마운트될 때마다 재요청하지 않도록 Promise 자체를 캐시.
+// 채널당 수백 KB 수준이지만 SPA 로 채널을 옮겨 다니면 누적되므로 상한을 둔다 (초과 시 가장 오래된 채널 제거).
+const MAX_INDEX_CACHE_SIZE = 5;
 const indexCache = new Map<string, Promise<EmojiIndexItem[]>>();
 
 export const getEmojiIndex = (channelId: string): Promise<EmojiIndexItem[]> => {
@@ -110,6 +112,11 @@ export const getEmojiIndex = (channelId: string): Promise<EmojiIndexItem[]> => {
     indexCache.delete(channelId); // 실패는 캐시하지 않음 → 다음 시도에서 재요청
     throw err;
   });
+
+  if (indexCache.size >= MAX_INDEX_CACHE_SIZE) {
+    const oldest = indexCache.keys().next().value; // Map 은 삽입 순서를 보존
+    if (oldest !== undefined) indexCache.delete(oldest);
+  }
   indexCache.set(channelId, fresh);
   return fresh;
 };

--- a/src/utils/emoji.ts
+++ b/src/utils/emoji.ts
@@ -1,0 +1,115 @@
+/**
+ * 치지직 이모티콘(emoji-packs) 인덱스 유틸.
+ * 검색 UI(ChatEmojiSearch)와 태그 모달(ChatEmojiTagModal)이 공용으로 사용한다.
+ */
+import { CHAT_EMOJI_TAGS } from '../constants/storage';
+
+// === emoji-packs API 응답 타입 (사용하는 필드만 선언) ===
+type Emoji = {
+  emojiId: string;
+  imageUrl: string;
+};
+
+type EmojiPack = {
+  emojiPackId: string;
+  emojiPackName: string;
+  emojiPackLocked: boolean;
+  emojiTier2Locked?: boolean;
+  emojis: Emoji[];
+  tier2Emojis?: Emoji[] | null;
+};
+
+type EmojiPacksContent = {
+  emojiPacks: EmojiPack[];
+  cheatKeyEmojiPacks: EmojiPack[];
+  subscriptionEmojiPacks: EmojiPack[];
+};
+
+export type EmojiIndexItem = {
+  emojiId: string;
+  imageUrl: string;
+  packId: string;
+  packName: string;
+};
+
+// 이모티콘별 사용자 태그. storage(CHAT_EMOJI_TAGS)에 저장되는 형태.
+export type EmojiTags = Record<string, string[]>;
+
+// 기본 태그 (치지직 기본 팩 대상). 최초 실행 시 1회 시드된다.
+const DEFAULT_EMOJI_TAGS: EmojiTags = {
+  d_139: ['ㅎㅇ'],
+  d_41: ['ㅎㅇ'],
+  d_11: ['ㅎㅇ'],
+  d_65: ['ㅋㅋ'],
+  d_44: ['ㅋㅋ'],
+  d_15: ['ㅋㅋ'],
+  d_123: ['?'],
+  d_73: ['?'],
+  d_67: ['?'],
+  d_59: ['춤'],
+  d_46: ['춤'],
+  d_42: ['춤'],
+};
+
+/**
+ * 저장된 태그를 불러온다. 저장소에 키 자체가 없으면(최초 실행) 기본 태그를 시드.
+ * 사용자가 태그를 전부 지운 상태({})는 undefined 와 구분되므로 다시 시드하지 않는다.
+ */
+export const loadEmojiTags = (): Promise<EmojiTags> =>
+  new Promise(resolve => {
+    chrome.storage.local.get([CHAT_EMOJI_TAGS], res => {
+      const stored = res[CHAT_EMOJI_TAGS] as EmojiTags | undefined;
+
+      if (stored === undefined) {
+        chrome.storage.local.set({ [CHAT_EMOJI_TAGS]: DEFAULT_EMOJI_TAGS });
+        resolve(DEFAULT_EMOJI_TAGS);
+        return;
+      }
+      resolve(stored);
+    });
+  });
+
+/**
+ * emoji-packs API 로 검색 인덱스를 만든다.
+ * - 3개 팩 배열(기본/치트키/구독)을 병합
+ * - 잠긴 팩(미구독), tier2 잠금 이모티콘은 사용할 수 없으므로 제외
+ */
+const fetchEmojiIndex = async (channelId: string): Promise<EmojiIndexItem[]> => {
+  const res = await fetch(`https://api.chzzk.naver.com/service/v1/channels/${channelId}/emoji-packs`, {
+    credentials: 'include',
+  });
+  if (!res.ok) throw new Error(`emoji-packs HTTP ${res.status}`);
+
+  const { content } = (await res.json()) as { content: EmojiPacksContent };
+  const packs = [...content.emojiPacks, ...content.cheatKeyEmojiPacks, ...content.subscriptionEmojiPacks];
+
+  return packs.flatMap(pack => {
+    if (pack.emojiPackLocked) return [];
+
+    const lockedTier2 = new Set((pack.emojiTier2Locked ? (pack.tier2Emojis ?? []) : []).map(e => e.emojiId));
+
+    return pack.emojis
+      .filter(e => !lockedTier2.has(e.emojiId))
+      .map(e => ({
+        emojiId: e.emojiId,
+        imageUrl: e.imageUrl,
+        packId: pack.emojiPackId,
+        packName: pack.emojiPackName,
+      }));
+  });
+};
+
+// 채널별 인덱스 캐시 — 검색 UI 와 태그 모달이 각자 마운트될 때마다 재요청하지 않도록 Promise 자체를 캐시.
+const indexCache = new Map<string, Promise<EmojiIndexItem[]>>();
+
+export const getEmojiIndex = (channelId: string): Promise<EmojiIndexItem[]> => {
+  const cached = indexCache.get(channelId);
+  if (cached) return cached;
+
+  const fresh = fetchEmojiIndex(channelId).catch(err => {
+    indexCache.delete(channelId); // 실패는 캐시하지 않음 → 다음 시도에서 재요청
+    throw err;
+  });
+  indexCache.set(channelId, fresh);
+  return fresh;
+};


### PR DESCRIPTION
## 내용

이모티콘 팝업에 **검색창**을 추가합니다.
이모티콘이 많아질수록 팩 탭을 뒤지기 어려워지는 문제를 해결합니다.

- 제안 이슈: #95 (승인 감사합니다!)
- 이슈에서 승인받은 검색 기능에 더해, 검색성을 보완하는 **사용자 태그 기능**을 함께 포함했습니다.
  이모티콘 코드가 비의미론적(`d_1`, `wc_3` 등)이라 코드 검색만으로는 한계가 있어서입니다.
  분리 리뷰가 좋으시면 태그 커밋(마지막 1개)만 별도 PR로 빼겠습니다.

> 드래프트: 하단 남은 작업 체크리스는 TBD

## 기능

### 이모티콘 검색
- 이모티콘 팝업 상단에 검색창 주입 (설정에서 on/off, 기본 off{미정})
- 이모티콘 코드·팩 이름·사용자 태그 부분 일치 검색
- 결과 클릭 시 입력창에 삽입 — **다른 팩의 이모티콘이면 해당 팩 탭으로 자동 전환 후 삽입**
- 미구독(잠긴) 팩 이모티콘은 결과에서 제외

### 키보드
- `Tab`/`Shift+Tab`: 결과 선택 순환 · `←→`/`↑↓`: 그리드 이동 (↑↓는 열 수 동적 계산)
- `Enter`: 삽입 · `Esc`: 팝업 닫기 (포커스 위치 무관)
- 팝업 열림 → 검색창 자동 포커스 / 닫힘 → 채팅 입력창 포커스 복귀 + 캐럿 맨 끝

### 이모티콘 태그
- 검색창 우측 태그 버튼 → 모달에서 이모티콘별 태그 추가/삭제
- 모달의 전체 태그 chip 클릭 → 해당 태그로 즉시 검색
- 최초 실행 시 기본 팩에 기본 태그 시드 (#ㅎㅇ #ㅋㅋ #? #춤) — 사용자가 지우면 다시 생기지 않음
- 저장: `chrome.storage.local` (`czp-chat-emoji-tags`, `Record<emojiId, string[]>`)

## 스크린샷

### 기본 사용법

<img width="954" height="700" alt="기본사용법" src="https://github.com/user-attachments/assets/bacee63a-2fa0-4039-81eb-03b8ef03d24f" />

### 태그 추가

<img width="954" height="700" alt="태그추가" src="https://github.com/user-attachments/assets/828bc116-99c5-4cbc-8ad9-85ea4b727a90" />

### 연속 입력

<img width="954" height="700" alt="연속입력" src="https://github.com/user-attachments/assets/65ed4024-0378-45ea-a4f2-a1cf4d3832f5" />

<img width="794" height="368" alt="설정창" src="https://github.com/user-attachments/assets/3794bdf3-4c32-483c-8592-ffcbd926b3d8" />
<img width="683" height="389" alt="image" src="https://github.com/user-attachments/assets/e80d7334-7c22-4074-8732-fa502f33341c" />


## 구현 노트

- 이모티콘 데이터는 `emoji-packs` API로 인덱싱 (`utils/emoji.ts`, 채널별 캐시)
- 팩 탭·채팅 입력창 포커스는 click이 아닌 **mousedown/mouseup**에 핸들러가 걸려 있어
  `dispatchMouseClickSequence` 유틸을 추가했습니다 (`utils/dom.ts`)
- 태그 모달은 `MessageStorageModal` 패턴(전역 마운트 + storage 플래그)을 따랐습니다
- 기존 미사용 상수 `CHAT_USER_AREA`의 오타를 수정했습니다 (`.area_` → `._area_`)
- `CHAT_INPUT` 상수는 `_default_` 클래스를 요구해 입력창에 내용이 있으면 매칭되지 않는
  문제가 있어, 포커스 용도의 `CHAT_INPUT_EDITABLE`(`pre[contenteditable="true"]`)을 추가했습니다

## 남은 작업 (드래프트 해제 전)

- [x] 윈도우에서 테스트
- [x] 테스트: 구독/비구독 채널, VOD, 넓은/전체 화면 전환, 채널 이동(SPA), 기능 off 시 원상복구
    - [x] 채팅 팝업 모드에서의 기능 활성화는 현재 스코프에서 다루기 어려울 것으로 보임
- [x] 라이트 모드에서 스타일 확인
- [x] 네이버 웨일에서 동작 확인
- [x] 검색 결과 다량 표시 시 팝업 레이아웃 확인
- [x] 스크린샷/GIF 첨부
- [x] `yarn build` 최종 확인

## 후속 계획 (별도 PR - 이건 사용자 반응 보고 결정해야할 것 같습니다.)

- 태그 JSON 내보내기/가져오기 (storage가 기기 로컬이라 이동 수단 필요)